### PR TITLE
FromRequest

### DIFF
--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -37,7 +37,7 @@ pub fn expand_json_api_models(ast: &DeriveInput) -> Tokens {
         .map(|&(field, ref ident)| {
             let ty = &field.ty;
             let option_ty = inner_of_option_ty(ty).unwrap_or(ty);
-            quote!(#ident: Option<#option_ty>)
+            quote!(pub #ident: Option<#option_ty>)
         })
         .collect();
 

--- a/rustiful-test/Cargo.toml
+++ b/rustiful-test/Cargo.toml
@@ -18,6 +18,9 @@ iron = "0.5.*"
 router = "0.5.*"
 iron-test = "0.5.*"
 clippy = {version = "0.0.123", optional = true}
+r2d2 = { version = "0.7" }
+r2d2-diesel = { version = "0.12" }
+lazy_static = "0.2"
 
 [features]
 default = []

--- a/rustiful-test/tests/lib.rs
+++ b/rustiful-test/tests/lib.rs
@@ -6,9 +6,9 @@ extern crate rustiful_derive;
 
 extern crate rustiful;
 
-use rustiful::SortOrder::*;
 use rustiful::JsonApiResource;
 use rustiful::QueryStringParseError;
+use rustiful::SortOrder::*;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
 struct Foo {

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -12,30 +12,31 @@ extern crate rustiful;
 extern crate serde_json;
 
 use self::router::Router;
+use iron::Headers;
+use iron::headers::ContentType;
+use iron::prelude::*;
+use iron_test::{request, response};
+use rustiful::FromRequest;
 
 use rustiful::JsonApiArray;
-use std::error::Error;
-use std::fmt::Display;
-use std::fmt::Formatter;
-use rustiful::JsonApiResource;
+use rustiful::JsonApiError;
+use rustiful::JsonApiErrorArray;
 use rustiful::JsonApiObject;
-use rustiful::JsonGet;
-use rustiful::JsonPost;
-use rustiful::JsonIndex;
+use rustiful::JsonApiResource;
 use rustiful::JsonDelete;
+use rustiful::JsonGet;
+use rustiful::JsonIndex;
+use rustiful::JsonPost;
+
+use rustiful::ToJson;
+use rustiful::iron::DeleteRouter;
 use rustiful::iron::GetRouter;
 use rustiful::iron::IndexRouter;
 use rustiful::iron::PostRouter;
-use rustiful::iron::DeleteRouter;
-use iron::headers::ContentType;
-use iron::Headers;
-use iron_test::{request, response};
-
-use rustiful::ToJson;
 use rustiful::status::Status;
-use rustiful::JsonApiError;
-use rustiful::JsonApiErrorArray;
-use iron::prelude::*;
+use std::error::Error;
+use std::fmt::Display;
+use std::fmt::Formatter;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
 struct Foo {
@@ -47,9 +48,10 @@ struct Foo {
 
 struct FooService;
 
-impl Default for FooService {
-    fn default() -> Self {
-        FooService {}
+impl FromRequest for FooService {
+    type Error = TestError;
+    fn from_request(request: &Request) -> Result<Self, Self::Error> {
+        Ok(FooService {})
     }
 }
 
@@ -72,7 +74,7 @@ impl Display for TestError {
     }
 }
 
-impl <'a> From<&'a TestError> for Status {
+impl<'a> From<&'a TestError> for Status {
     fn from(error: &'a TestError) -> Self {
         rustiful::status::ImATeapot
     }
@@ -199,11 +201,11 @@ fn parse_json_api_custom_failure() {
 
     let expected = JsonApiErrorArray {
         errors: vec![JsonApiError {
-            detail: "fail".to_string(),
-            status: "418".to_string(),
-            title: "fail".to_string()
-        }]
+                         detail: "fail".to_string(),
+                         status: "418".to_string(),
+                         title: "fail".to_string(),
+                     }],
     };
 
-   assert_eq!(expected, record);
+    assert_eq!(expected, record);
 }

--- a/rustiful-test/tests/service_tests.rs
+++ b/rustiful-test/tests/service_tests.rs
@@ -10,25 +10,37 @@ extern crate diesel;
 #[macro_use]
 extern crate diesel_codegen;
 
+#[macro_use]
+extern crate lazy_static;
+
+extern crate r2d2;
+extern crate r2d2_diesel;
 extern crate uuid;
-
 extern crate rustiful;
+extern crate iron;
+extern crate dotenv;
 
-use uuid::Uuid;
-use rustiful::SortOrder::*;
+use self::iron::prelude::*;
 use diesel::*;
+use diesel::sqlite::SqliteConnection;
+use dotenv::dotenv;
+use r2d2::GetTimeout;
+use r2d2::Pool;
+use r2d2::PooledConnection;
+use r2d2_diesel::ConnectionManager;
 use rustiful::*;
+use rustiful::SortOrder::*;
+use rustiful::status::Status;
+use std::env;
 use std::error::Error;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use rustiful::status::Status;
+use uuid::Uuid;
 
-type TestConnection = ::diesel::sqlite::SqliteConnection;
+infer_schema!("dotenv:DATABASE_URL");
 
-infer_schema!("/tmp/test.db");
-
-use self::tests::dsl::tests as table;
 use self::tests as column;
+use self::tests::dsl::tests as table;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi, Queryable, Insertable)]
 #[table_name="tests"]
@@ -39,133 +51,157 @@ struct Test {
     published: bool,
 }
 
-struct TestService;
-
 #[derive(Debug)]
-struct MyDieselError(diesel::result::Error);
+enum MyErr {
+    Diesel(diesel::result::Error),
+}
 
-impl Error for MyDieselError {
+impl Error for MyErr {
     fn description(&self) -> &str {
-        self.0.description()
+        match *self {
+            MyErr::Diesel(ref err) => err.description(),
+        }
     }
 
     fn cause(&self) -> Option<&Error> {
-        self.0.cause()
+        match *self {
+            MyErr::Diesel(ref err) => err.cause(),
+        }
     }
 }
 
-impl Display for MyDieselError {
+impl Display for MyErr {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        self.0.fmt(f)
+        match *self {
+            MyErr::Diesel(ref err) => err.fmt(f),
+        }
     }
 }
 
-impl Default for TestService {
-    fn default() -> Self {
-        TestService {}
+impl FromRequest for DB {
+    type Error = GetTimeout;
+
+    fn from_request(_: &Request) -> Result<DB, Self::Error> {
+        match DB_POOL.get() {
+            Ok(conn) => Ok(DB(conn)),
+            Err(e) => Err(e),
+        }
     }
 }
 
-impl <'a> From<&'a MyDieselError> for Status {
-    fn from(error: &'a MyDieselError) -> Self {
+impl<'a> From<&'a MyErr> for Status {
+    fn from(_: &'a MyErr) -> Self {
         rustiful::status::InternalServerError
     }
 }
 
 impl JsonGet for Test {
-    type Error = MyDieselError;
-    type Context = TestService;
+    type Error = MyErr;
+    type Context = DB;
 
     fn find(id: Self::JsonApiIdType,
-            params: &Self::Params,
+            _: &Self::Params,
             ctx: Self::Context)
             -> Result<Option<Self>, Self::Error> {
-        table.find(id).first(&connection()).optional().map_err(|e| MyDieselError(e))
+        table.find(id).first(ctx.conn()).optional().map_err(|e| MyErr::Diesel(e))
     }
 }
 
 impl JsonPost for Test {
-    type Error = MyDieselError;
-    type Context = TestService;
+    type Error = MyErr;
+    type Context = DB;
 
     fn create(record: Self::Resource, ctx: Self::Context) -> Result<Self, Self::Error> {
-        //diesel::insert(&record).into(table).execute(&connection()).map(|_| record)
-        // TODO: Add try_into for test
-        Ok(Test {
-            id: "1".to_string(),
-            title: "1".to_string(),
-            body: "1".to_string(),
-            published: true
-        })
+        let result: Test = record.into();
+        diesel::insert(&result)
+            .into(table)
+            .execute(ctx.conn())
+            .map_err(|e| MyErr::Diesel(e))
+            .map(|_| result)
     }
 }
 
 impl JsonIndex for Test {
-    type Error = MyDieselError;
-    type Context = TestService;
+    type Error = MyErr;
+    type Context = DB;
 
     fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<Self>, Self::Error> {
-        use self::test::sort::*;
-
         let mut query = table.into_boxed();
 
-        for order in &params.sort.fields {
-            match order {
-                &title(Asc) => {
-                    query = query.order(column::title);
-                }
-                &title(Desc) => {
-                    query = query.order(column::title.desc());
-                }
-                &body(Asc) => {
-                    query = query.order(column::body);
-                }
-                &body(Desc) => {
-                    query = query.order(column::body.desc());
-                }
-                &published(Asc) => {
-                    query = query.order(column::published);
-                }
-                &published(Desc) => {
-                    query = query.order(column::published.desc());
-                }
-            };
+        {
+            use self::test::sort::*;
+            for order in &params.sort.fields {
+                match *order {
+                    title(Asc) => {
+                        query = query.order(column::title);
+                    }
+                    title(Desc) => {
+                        query = query.order(column::title.desc());
+                    }
+                    body(Asc) => {
+                        query = query.order(column::body);
+                    }
+                    body(Desc) => {
+                        query = query.order(column::body.desc());
+                    }
+                    published(Asc) => {
+                        query = query.order(column::published);
+                    }
+                    published(Desc) => {
+                        query = query.order(column::published.desc());
+                    }
+                };
+            }
         }
 
-        query.load(&connection()).map_err(|e| MyDieselError(e))
+        query.load(ctx.conn()).map_err(|e| MyErr::Diesel(e))
     }
 }
 
 impl JsonDelete for Test {
-    type Error = MyDieselError;
-    type Context = TestService;
+    type Error = MyErr;
+    type Context = DB;
 
     fn delete(id: Self::JsonApiIdType, ctx: Self::Context) -> Result<(), Self::Error> {
-        diesel::delete(table.find(id)).execute(&connection()).map(|_| ()).map_err(|e| MyDieselError(e))
+        diesel::delete(table.find(id)).execute(ctx.conn()).map(|_| ()).map_err(|e| MyErr::Diesel(e))
     }
 }
 
 
-impl TryFrom<<Test as ToJson>::Resource> for Test {
-    type Error = QueryStringParseError;
-
-    fn try_from(json: <Test as ToJson>::Resource) -> Result<Self, Self::Error> {
-        Err(QueryStringParseError::UnImplementedError)
+impl From<<Test as ToJson>::Resource> for Test {
+    fn from(json: <Test as ToJson>::Resource) -> Self {
+        Test {
+            id: json.id.map(|id| id.into()).unwrap_or_else(|| Uuid::new_v4().to_string()),
+            title: json.attributes.title.unwrap_or("".to_string()),
+            body: json.attributes.body.unwrap_or("".to_string()),
+            published: json.attributes.published.unwrap_or(false),
+        }
     }
 }
 
-fn connection() -> TestConnection {
-    let result = connection_without_transaction();
-    result
+lazy_static! {
+    pub static ref DB_POOL: Pool<ConnectionManager<SqliteConnection>> = create_db_pool();
 }
 
-fn connection_without_transaction() -> TestConnection {
-    let connection = ::diesel::sqlite::SqliteConnection::establish("/tmp/test.db").unwrap();
-    connection
+pub struct DB(PooledConnection<ConnectionManager<SqliteConnection>>);
+
+impl DB {
+    pub fn conn(&self) -> &SqliteConnection {
+        &*self.0
+    }
+}
+
+pub fn create_db_pool() -> Pool<ConnectionManager<SqliteConnection>> {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let config = r2d2::Config::default();
+    let manager = ConnectionManager::<SqliteConnection>::new(database_url);
+    Pool::new(config, manager).expect("Failed to create pool.")
 }
 
 #[test]
-fn test() {
+fn test_get_and_create() {
     let id = Uuid::new_v4().to_string();
     let model = Test {
         id: id.clone(),
@@ -173,8 +209,15 @@ fn test() {
         body: "1".to_string(),
         published: true,
     };
-    let service = TestService {};
+
+    Test::create(model.clone().into(),
+                 DB(DB_POOL.get().expect("cannot get connection")))
+        .unwrap();
     let params = <Test as JsonApiResource>::from_str("").unwrap();
-    Test::create(model.clone().into(), service).unwrap();
-    assert_eq!(model, Test::find(id, &params, Default::default()).unwrap().unwrap());
+    assert_eq!(model,
+               Test::find(id,
+                          &params,
+                          DB(DB_POOL.get().expect("cannot get connection")))
+                   .unwrap()
+                   .unwrap());
 }

--- a/rustiful/src/id.rs
+++ b/rustiful/src/id.rs
@@ -25,9 +25,29 @@ impl From<String> for JsonApiId {
     }
 }
 
+impl From<JsonApiId> for String {
+    fn from(value: JsonApiId) -> Self {
+        if let JsonApiIdType::Str(str) = value.0 {
+            str
+        } else {
+            panic!("Expected String!")
+        }
+    }
+}
+
 impl From<i32> for JsonApiId {
     fn from(value: i32) -> Self {
         JsonApiId(JsonApiIdType::Int32(value))
+    }
+}
+
+impl From<JsonApiId> for i32 {
+    fn from(value: JsonApiId) -> Self {
+        if let JsonApiIdType::Int32(val) = value.0 {
+            val
+        } else {
+            panic!("Expected int32!")
+        }
     }
 }
 
@@ -37,9 +57,30 @@ impl From<i64> for JsonApiId {
     }
 }
 
+impl From<JsonApiId> for i64 {
+    fn from(value: JsonApiId) -> Self {
+        if let JsonApiIdType::Int64(val) = value.0 {
+            val
+        } else {
+            panic!("Expected int64!")
+        }
+    }
+}
+
+
 impl From<u32> for JsonApiId {
     fn from(value: u32) -> Self {
         JsonApiId(JsonApiIdType::UInt32(value))
+    }
+}
+
+impl From<JsonApiId> for u32 {
+    fn from(value: JsonApiId) -> Self {
+        if let JsonApiIdType::UInt32(val) = value.0 {
+            val
+        } else {
+            panic!("Expected uint32!")
+        }
     }
 }
 
@@ -49,9 +90,30 @@ impl From<u64> for JsonApiId {
     }
 }
 
+impl From<JsonApiId> for u64 {
+    fn from(value: JsonApiId) -> Self {
+        if let JsonApiIdType::UInt64(val) = value.0 {
+            val
+        } else {
+            panic!("Expected uint64!")
+        }
+    }
+}
+
 #[cfg(feature = "uuid")]
 impl From<Uuid> for JsonApiId {
     fn from(value: Uuid) -> Self {
         JsonApiId(JsonApiIdType::Uuid(value))
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl From<JsonApiId> for Uuid {
+    fn from(value: JsonApiId) -> Self {
+        if let JsonApiIdType::Uuid(val) = value.0 {
+            val
+        } else {
+            panic!("Expected uuid!")
+        }
     }
 }

--- a/rustiful/src/iron/from_request.rs
+++ b/rustiful/src/iron/from_request.rs
@@ -1,0 +1,10 @@
+extern crate iron;
+
+use self::iron::prelude::*;
+use std;
+
+pub trait FromRequest: Sized {
+    type Error: std::error::Error + Send;
+
+    fn from_request(request: &Request) -> Result<Self, Self::Error>;
+}

--- a/rustiful/src/iron/handlers/delete.rs
+++ b/rustiful/src/iron/handlers/delete.rs
@@ -3,6 +3,7 @@ extern crate iron;
 use self::iron::prelude::*;
 use super::Status;
 use super::super::RequestResult;
+use ::FromRequest;
 use iron::id;
 use request::FromDelete;
 use service::JsonDelete;
@@ -15,11 +16,17 @@ autoimpl! {
         where T: JsonDelete + FromDelete<'a, T>,
               T::Error: 'static,
               Status: for<'b> From<&'b T::Error>,
+              <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
         fn delete(req: &'a mut Request) -> IronResult<Response> {
-            let result = <T as FromDelete<T>>::delete(id(req), Default::default());
-            RequestResult(result, Status::NoContent).try_into()
+            match FromRequest::from_request(req) {
+                Ok(res) => {
+                    let result = <T as FromDelete<T>>::delete(id(req), res);
+                    RequestResult(result, Status::NoContent).try_into()
+                },
+                Err(e) => Err(IronError::new(e, Status::InternalServerError))
+            }
         }
     }
 }

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -1,4 +1,5 @@
 mod handlers;
+pub mod from_request;
 
 extern crate iron;
 extern crate router;
@@ -10,6 +11,7 @@ use self::handlers::*;
 use self::iron::mime::Mime;
 use self::iron::prelude::*;
 use self::iron::status;
+use ::FromRequest;
 use error::JsonApiErrorArray;
 use errors::QueryStringParseError;
 use errors::RequestError;
@@ -80,6 +82,7 @@ pub fn id<'a>(req: &'a Request) -> &'a str {
 pub trait DeleteRouter {
     fn jsonapi_delete<'a, T>(&mut self)
         where T: JsonDelete + JsonApiResource + ToJson + for<'b> DeleteHandler<'b, T>,
+              <T::Context as FromRequest>::Error: 'static,
               T::Error: Send + 'static,
               Status: for<'b> From<&'b T::Error>,
               T::JsonApiIdType: FromStr,
@@ -89,6 +92,7 @@ pub trait DeleteRouter {
 impl DeleteRouter for Router {
     fn jsonapi_delete<'a, T>(&mut self)
         where T: JsonDelete + JsonApiResource + ToJson + for<'b> DeleteHandler<'b, T>,
+              <T::Context as FromRequest>::Error: 'static,
               T::Error: Send + 'static,
               Status: for<'b> From<&'b T::Error>,
               T::JsonApiIdType: FromStr,
@@ -109,6 +113,7 @@ pub trait GetRouter {
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
               Status: for<'b> From<&'b T::Error>,
+              <<T as JsonGet>::Context as FromRequest>::Error: 'static,
               T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
                                          Error = QueryStringParseError>,
               T::Params: for<'b> TryFrom<(&'b str, SortOrder, T::Params),
@@ -123,6 +128,7 @@ impl GetRouter for Router {
         where T: JsonGet + JsonApiResource + ToJson + for<'b> GetHandler<'b, T>,
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
+              <<T as JsonGet>::Context as FromRequest>::Error: 'static,
               Status: for<'b> From<&'b T::Error>,
               T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
                                          Error = QueryStringParseError>,
@@ -143,6 +149,7 @@ pub trait IndexRouter {
     fn jsonapi_index<'a, T>(&mut self)
         where T: JsonIndex + JsonApiResource + ToJson + for<'b> IndexHandler<'b, T>,
               T::Error: Send + 'static,
+              <<T as JsonIndex>::Context as FromRequest>::Error: 'static,
               T::JsonApiIdType: FromStr,
               Status: for<'b> From<&'b T::Error>,
               T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
@@ -158,6 +165,7 @@ impl IndexRouter for Router {
     fn jsonapi_index<'a, T>(&mut self)
         where T: JsonIndex + JsonApiResource + ToJson + for<'b> IndexHandler<'b, T>,
               T::Error: Send + 'static,
+              <<T as JsonIndex>::Context as FromRequest>::Error: 'static,
               T::JsonApiIdType: FromStr,
               Status: for<'b> From<&'b T::Error>,
               T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
@@ -179,6 +187,7 @@ pub trait PostRouter {
     fn jsonapi_post<'a, T>(&mut self) where
         T: JsonPost + JsonApiResource + ToJson + for<'b> PostHandler<'b, T>,
         T::Error : Send + 'static,
+        <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
         T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
@@ -194,6 +203,7 @@ impl PostRouter for Router {
     fn jsonapi_post<'a, T>(&mut self) where
         T: JsonPost + JsonApiResource + ToJson + for<'b> PostHandler<'b, T>,
         T::Error : Send + 'static,
+        <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
         T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
@@ -214,6 +224,7 @@ pub trait PatchRouter {
     fn jsonapi_patch<'a, T>(&mut self) where
         T: JsonPatch + JsonApiResource + ToJson + for<'b> PatchHandler<'b, T>,
         T::Error : Send + 'static,
+        <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
         T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
@@ -229,6 +240,7 @@ impl PatchRouter for Router {
     fn jsonapi_patch<'a, T>(&mut self) where
         T: JsonPatch + JsonApiResource + ToJson + for<'b> PatchHandler<'b, T>,
         T::Error : Send + 'static,
+        <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
         T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -44,6 +44,9 @@ mod request;
 #[cfg(feature = "iron")]
 pub mod iron;
 
+#[cfg(feature = "iron")]
+pub use iron::from_request::*;
+
 #[macro_use]
 extern crate serde_derive;
 

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -1,16 +1,16 @@
 extern crate serde;
 
+use FromRequest;
 use params::JsonApiResource;
 use status::Status;
 use std;
 use to_json::ToJson;
 
-
 pub trait JsonGet
     where Self: JsonApiResource
 {
     type Error: std::error::Error + Send;
-    type Context: Default;
+    type Context: FromRequest;
 
     fn find(id: Self::JsonApiIdType,
             params: &Self::Params,
@@ -23,7 +23,7 @@ pub trait JsonPost
     where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
-    type Context: Default;
+    type Context: FromRequest;
 
     fn create(json: Self::Resource, ctx: Self::Context) -> Result<Self, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
@@ -33,7 +33,7 @@ pub trait JsonPatch
     where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
-    type Context: Default;
+    type Context: FromRequest;
 
     fn update(id: Self::JsonApiIdType,
               json: Self::Resource,
@@ -46,7 +46,7 @@ pub trait JsonIndex
     where Self: JsonApiResource
 {
     type Error: std::error::Error + Send;
-    type Context: Default;
+    type Context: FromRequest;
 
     fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<Self>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
@@ -56,7 +56,7 @@ pub trait JsonDelete
     where Self: JsonApiResource
 {
     type Error: std::error::Error + Send;
-    type Context: Default;
+    type Context: FromRequest;
 
     fn delete(id: Self::JsonApiIdType, ctx: Self::Context) -> Result<(), Self::Error>
         where Status: for<'b> From<&'b Self::Error>;


### PR DESCRIPTION
This PR replaces the bounds of the `Context` type from `Default` to `FromRequest`. The reason we want to replace this bound is so that we have the ability to construct the `Context` type based on parameters from the incoming request, such as cookies, query params etc.