### PR TITLE
Fix POSTs of JSON documents

### DIFF
--- a/rustiful-test/Cargo.toml
+++ b/rustiful-test/Cargo.toml
@@ -21,6 +21,8 @@ clippy = {version = "0.0.123", optional = true}
 r2d2 = { version = "0.7" }
 r2d2-diesel = { version = "0.12" }
 lazy_static = "0.2"
+bodyparser = { version = "0.6.*" }
+persistent = "0.3.0"
 
 [features]
 default = []

--- a/rustiful-test/migrations/20170226214138_create_tests/up.sql
+++ b/rustiful-test/migrations/20170226214138_create_tests/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE tests (
   id VARCHAR PRIMARY KEY NOT NULL,
   title VARCHAR NOT NULL,
-  body TEXT NOT NULL,
+  body TEXT,
   published BOOLEAN NOT NULL DEFAULT 'f'
 )

--- a/rustiful-test/tests/post_and_patch_tests.rs
+++ b/rustiful-test/tests/post_and_patch_tests.rs
@@ -1,0 +1,428 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[macro_use]
+extern crate rustiful_derive;
+
+#[macro_use]
+extern crate diesel;
+
+#[macro_use]
+extern crate diesel_codegen;
+
+#[macro_use]
+extern crate lazy_static;
+
+extern crate iron;
+extern crate router;
+extern crate iron_test;
+extern crate uuid;
+extern crate rustiful;
+extern crate serde_json;
+extern crate r2d2;
+extern crate r2d2_diesel;
+extern crate dotenv;
+extern crate bodyparser;
+extern crate persistent;
+
+use self::router::Router;
+use rustiful::JsonApiId;
+use iron::mime::Mime;
+use persistent::Read;
+use iron::Headers;
+use iron::headers::ContentType;
+use iron::prelude::*;
+use iron_test::{request, response};
+use rustiful::FromRequest;
+
+use rustiful::JsonApiArray;
+use rustiful::JsonApiError;
+use rustiful::iron::PatchRouter;
+use rustiful::JsonApiErrorArray;
+use rustiful::JsonApiObject;
+use rustiful::JsonApiResource;
+use rustiful::JsonDelete;
+use rustiful::JsonGet;
+use rustiful::JsonIndex;
+use rustiful::JsonPost;
+use rustiful::JsonPatch;
+use rustiful::ToJson;
+use rustiful::iron::DeleteRouter;
+use rustiful::iron::GetRouter;
+use rustiful::iron::IndexRouter;
+use rustiful::iron::PostRouter;
+use rustiful::status::Status;
+use std::error::Error;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use diesel::*;
+use diesel::sqlite::SqliteConnection;
+use dotenv::dotenv;
+use r2d2::GetTimeout;
+use r2d2::Pool;
+use r2d2::PooledConnection;
+use r2d2_diesel::ConnectionManager;
+use std::env;
+use uuid::Uuid;
+use rustiful::TryInto;
+
+infer_schema!("dotenv:DATABASE_URL");
+
+use self::tests as column;
+use self::tests::dsl::tests as table;
+
+
+const MAX_BODY_LENGTH: usize = 1024 * 1024 * 100;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi, Queryable, Insertable,
+AsChangeset)]
+#[table_name="tests"]
+struct Test {
+    id: String,
+    title: String,
+    body: Option<String>,
+    published: bool,
+}
+
+#[derive(Debug)]
+enum MyErr {
+    Diesel(diesel::result::Error),
+    UpdateError(String)
+}
+
+impl Error for MyErr {
+    fn description(&self) -> &str {
+        match *self {
+            MyErr::Diesel(ref err) => err.description(),
+            MyErr::UpdateError(ref err) => err,
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            MyErr::Diesel(ref err) => err.cause(),
+            MyErr::UpdateError(_) => None,
+        }
+    }
+}
+
+impl Display for MyErr {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match *self {
+            MyErr::Diesel(ref err) => err.fmt(f),
+            MyErr::UpdateError(ref err) => f.write_str("wat"),
+        }
+    }
+}
+
+impl FromRequest for DB {
+    type Error = GetTimeout;
+
+    fn from_request(_: &Request) -> Result<DB, Self::Error> {
+        match DB_POOL.get() {
+            Ok(conn) => Ok(DB(conn)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<'a> From<&'a MyErr> for Status {
+    fn from(err: &'a MyErr) -> Self {
+        match *err {
+            MyErr::UpdateError(_) => rustiful::status::ImATeapot,
+            _ => rustiful::status::InternalServerError
+        }
+    }
+}
+
+impl JsonGet for Test {
+    type Error = MyErr;
+    type Context = DB;
+
+    fn find(id: Self::JsonApiIdType,
+            _: &Self::Params,
+            ctx: Self::Context)
+            -> Result<Option<Self>, Self::Error> {
+        if id == "fail" {
+            return Err(MyErr::UpdateError("test fail".to_string()))
+        }
+        table.find(id).first(ctx.conn()).optional().map_err(|e| MyErr::Diesel(e))
+    }
+}
+
+impl JsonPatch for Test {
+    type Error = MyErr;
+    type Context = DB;
+
+    fn update(id: Self::JsonApiIdType,
+              json: Self::Resource,
+              ctx: Self::Context)
+              -> Result<Self, Self::Error> {
+        let record = table.find(&id).first(ctx.conn()).map_err(|e| MyErr::Diesel(e))?;
+        let patch = (record, json).try_into().map_err(|e| MyErr::UpdateError(e))?;
+        diesel::update(table.find(&id)).set(&patch).execute(ctx.conn()).map_err(|e| MyErr::Diesel(e))?;
+        Ok(patch)
+    }
+}
+
+impl JsonIndex for Test {
+    type Error = MyErr;
+    type Context = DB;
+
+    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<Self>, Self::Error> {
+        let mut query = table.into_boxed();
+
+        {
+            use self::test::sort::*;
+            for order in &params.sort.fields {
+                match *order {
+                    title(Asc) => {
+                        query = query.order(column::title);
+                    }
+                    title(Desc) => {
+                        query = query.order(column::title.desc());
+                    }
+                    body(Asc) => {
+                        query = query.order(column::body);
+                    }
+                    body(Desc) => {
+                        query = query.order(column::body.desc());
+                    }
+                    published(Asc) => {
+                        query = query.order(column::published);
+                    }
+                    published(Desc) => {
+                        query = query.order(column::published.desc());
+                    }
+                };
+            }
+        }
+
+        query.load(ctx.conn()).map_err(|e| MyErr::Diesel(e))
+    }
+}
+
+impl JsonDelete for Test {
+    type Error = MyErr;
+    type Context = DB;
+
+    fn delete(id: Self::JsonApiIdType, ctx: Self::Context) -> Result<(), Self::Error> {
+        diesel::delete(table.find(id)).execute(ctx.conn()).map(|_| ()).map_err(|e| MyErr::Diesel(e))
+    }
+}
+
+impl JsonPost for Test {
+    type Error = MyErr;
+    type Context = DB;
+
+    fn create(record: Self::Resource, ctx: Self::Context) -> Result<Self, Self::Error> {
+        let result: Test = record.into();
+        diesel::insert(&result)
+            .into(table)
+            .execute(ctx.conn())
+            .map_err(|e| MyErr::Diesel(e))
+            .map(|_| result)
+    }
+}
+
+
+
+impl From<<Test as ToJson>::Resource> for Test {
+    fn from(json: <Test as ToJson>::Resource) -> Self {
+        Test {
+            id: json.id.map(|id| id.into()).unwrap_or_else(|| Uuid::new_v4().to_string()),
+            title: json.attributes.title.unwrap_or("".to_string()),
+            body: json.attributes.body.unwrap(),
+            published: json.attributes.published.unwrap_or(false),
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref DB_POOL: Pool<ConnectionManager<SqliteConnection>> = create_db_pool();
+}
+
+pub struct DB(PooledConnection<ConnectionManager<SqliteConnection>>);
+
+impl DB {
+    pub fn conn(&self) -> &SqliteConnection {
+        &*self.0
+    }
+}
+
+pub fn create_db_pool() -> Pool<ConnectionManager<SqliteConnection>> {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let config = r2d2::Config::default();
+    let manager = ConnectionManager::<SqliteConnection>::new(database_url);
+    Pool::new(config, manager).expect("Failed to create pool.")
+}
+
+fn app_router() -> iron::Chain {
+    let mut router = Router::new();
+    router.jsonapi_get::<Test>();
+    router.jsonapi_post::<Test>();
+    router.jsonapi_index::<Test>();
+    router.jsonapi_patch::<Test>();
+    router.jsonapi_delete::<Test>();
+    let mut chain = iron::Chain::new(router);
+    chain.link_before(Read::<bodyparser::MaxBodyLength>::one(MAX_BODY_LENGTH));
+    chain
+}
+
+#[test]
+#[ignore] // Ignored by default since we need to run this sequentially, due to SQLite locking.
+fn post_without_client_generated_id() {
+    let data = r#"
+    {
+        "data": {
+            "type": "tests",
+            "attributes": {
+                "body": "test",
+                "title": "test",
+                "published": true
+            }
+        }
+    }"#;
+
+    let created = do_post(&data);
+    let retrieved = do_get(&created.clone().data.id.unwrap());
+
+    assert_eq!(created, retrieved);
+}
+
+#[test]
+#[ignore] // Ignored by default since we need to run this sequentially, due to SQLite locking.
+fn post_with_client_generated_id() {
+    let id = Uuid::new_v4().to_string();
+    let data = format!(r#"
+    {{
+        "data": {{
+            "id": "{}",
+            "type": "tests",
+            "attributes": {{
+                "body": "test",
+                "title": "test",
+                "published": true
+            }}
+        }}
+    }}"#, id);
+
+    let created = do_post(&data);
+    let retrieved = do_get(&id);
+
+    assert_eq!(created, retrieved);
+}
+
+#[test]
+#[ignore] // Ignored by default since we need to run this sequentially, due to SQLite locking.
+fn update_with_nullable_field() {
+    let id = Uuid::new_v4().to_string();
+    let data = format!(r#"
+    {{
+        "data": {{
+            "id": "{}",
+            "type": "tests",
+            "attributes": {{
+                "body": "test",
+                "title": "test",
+                "published": true
+            }}
+        }}
+    }}"#, &id);
+
+    do_post(&data);
+
+    {
+        let patch = format!(r#"
+        {{
+            "data": {{
+                "id": "{}",
+                "type": "tests",
+                "attributes": {{
+                    "title": "funky"
+                }}
+            }}
+        }}"#, &id);
+
+        do_patch(&id, &patch);
+
+
+        let retrieved = do_get(&id);
+        assert_eq!(Some("test".to_string()), retrieved.data.attributes.body.unwrap());
+        assert_eq!(Some("funky".to_string()), retrieved.data.attributes.title);
+    }
+
+    {
+        let patch = format!(r#"
+        {{
+            "data": {{
+                "id": "{}",
+                "type": "tests",
+                "attributes": {{
+                    "body": "new_content"
+                }}
+            }}
+        }}"#, &id);
+
+        do_patch(&id, &patch);
+
+        let retrieved = do_get(&id);
+        assert_eq!(Some("new_content".to_string()), retrieved.data.attributes.body.unwrap());
+    }
+
+    {
+        let patch = format!(r#"
+        {{
+            "data": {{
+                "id": "{}",
+                "type": "tests",
+                "attributes": {{
+                    "body": null
+                }}
+            }}
+        }}"#, &id);
+
+        do_patch(&id, &patch);
+
+        let retrieved = do_get(&id);
+        assert_eq!(None, retrieved.data.attributes.body.unwrap());
+    }
+}
+
+fn do_get<T: Display>(id: &T) -> JsonApiObject<<Test as ToJson>::Attrs> {
+    let response = request::get(&format!("http://localhost:3000/tests/{}", id),
+                                Headers::new(),
+                                &app_router());
+    let result = response::extract_body_to_string(response.unwrap());
+    let retrieved: JsonApiObject<<Test as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
+    retrieved
+}
+
+fn do_post(json: &str) -> JsonApiObject<<Test as ToJson>::Attrs> {
+    let content_type: Mime = "application/vnd.api+json".parse().unwrap();
+
+    let mut headers = Headers::new();
+    headers.set::<ContentType>(ContentType(content_type));
+
+    let response = request::post("http://localhost:3000/tests", headers, &json, &app_router());
+    let result = response::extract_body_to_string(response.unwrap());
+
+    let created: JsonApiObject<<Test as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
+    created
+}
+
+fn do_patch<T: Display>(id: &T, json: &str) -> JsonApiObject<<Test as ToJson>::Attrs> {
+    let content_type: Mime = "application/vnd.api+json".parse().unwrap();
+
+    let mut headers = Headers::new();
+    headers.set::<ContentType>(ContentType(content_type));
+
+    let response = request::patch(&format!("http://localhost:3000/tests/{}", id), headers, &json, &app_router());
+    let result = response::extract_body_to_string(response.unwrap());
+
+    let created: JsonApiObject<<Test as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
+    created
+}

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -176,7 +176,7 @@ fn parse_json_api_single_get() {
                                 Headers::new(),
                                 &app_router());
     let result = response::extract_body_to_string(response.unwrap());
-    let record: JsonApiObject<<Foo as ToJson>::Resource> = serde_json::from_str(&result).unwrap();
+    let record: JsonApiObject<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
     let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
@@ -186,7 +186,7 @@ fn parse_json_api_single_get() {
         published: true,
     };
     let data: <Foo as ToJson>::Resource = (test, &params).into();
-    let expected: JsonApiObject<<Foo as ToJson>::Resource> = JsonApiObject { data: data };
+    let expected: JsonApiObject<<Foo as ToJson>::Attrs> = JsonApiObject { data: data };
 
     assert_eq!(expected, record);
 }

--- a/rustiful/src/id.rs
+++ b/rustiful/src/id.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "uuid")]
 extern crate uuid;
 
+use std::fmt;
+
 #[cfg(feature = "uuid")]
 use self::uuid::Uuid;
 
@@ -114,6 +116,22 @@ impl From<JsonApiId> for Uuid {
             val
         } else {
             panic!("Expected uuid!")
+        }
+    }
+}
+
+impl fmt::Display for JsonApiId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::JsonApiIdType::*;
+
+        match self.0 {
+            Str(ref val) => write!(f, "{}", val),
+            Int32(ref val) => write!(f, "{}", val),
+            Int64(ref val) => write!(f, "{}", val),
+            UInt32(ref val) => write!(f, "{}", val),
+            UInt64(ref val) => write!(f, "{}", val),
+            #[cfg(feature = "uuid")]
+            Uuid(ref val) => write!(f, "{}", val),
         }
     }
 }

--- a/rustiful/src/iron/handlers/post.rs
+++ b/rustiful/src/iron/handlers/post.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 use try_from::TryInto;
+use object::JsonApiObject;
 
 autoimpl! {
     pub trait PostHandler<'a, T> where
@@ -28,19 +29,18 @@ autoimpl! {
         T::Error: 'static,
         <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
-        T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
         T::Params: TryFrom<(&'a str, Vec<&'a str>, T::Params), Error = QueryStringParseError>,
         T::Params: TryFrom<(&'a str, SortOrder, T::Params), Error = QueryStringParseError>,
         T::Params: TypedParams<T::SortField, T::FilterField> + Default,
-        T::Attrs: for<'b> From<(T, &'b T::Params)>,
+        T::Attrs: for<'b> From<(T, &'b T::Params)> + 'static,
         <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
         fn post(req: &'a mut Request) -> IronResult<Response> {
-            match req.get::<bodyparser::Struct<T::Resource>>() {
+            match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
                 Ok(Some(post)) => {
                     match FromRequest::from_request(req) {
                         Ok(res) => {
-                            let result = <T as FromPost<T>>::create(post, res);
+                            let result = <T as FromPost<T>>::create(post.data, res);
                             RequestResult(result, Status::Created).try_into()
                         },
                         Err(e) => Err(IronError::new(e, Status::InternalServerError))

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -50,7 +50,7 @@ impl<T, E> TryFrom<RequestResult<T, E>> for Response
                     Ok(serialized) => {
                         let status = request.1;
                         match status {
-                            Status::Created | Status::NoContent => {
+                            Status::NoContent => {
                                 Ok(Response::with((content_type, status)))
                             }
                             _ => Ok(Response::with((content_type, status, serialized))),
@@ -190,12 +190,11 @@ pub trait PostRouter {
         <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
-        T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
         T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
                                     Error = QueryStringParseError>,
         T::Params: for<'b> TryFrom<(&'b str, SortOrder, T::Params),
                                     Error = QueryStringParseError>,
-        T::Attrs: for<'b> From<(T, &'b T::Params)>,
+        T::Attrs: for<'b> From<(T, &'b T::Params)> + 'static,
         <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static;
 }
 
@@ -206,12 +205,11 @@ impl PostRouter for Router {
         <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
-        T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
         T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
                                     Error = QueryStringParseError>,
         T::Params: for<'b> TryFrom<(&'b str, SortOrder, T::Params),
                                     Error = QueryStringParseError>,
-        T::Attrs: for<'b> From<(T, &'b T::Params)>,
+        T::Attrs: for<'b> From<(T, &'b T::Params)> + 'static,
         <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static {
 
         self.post(format!("/{}", T::resource_name()),
@@ -227,12 +225,11 @@ pub trait PatchRouter {
         <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
-        T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
         T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
                                     Error = QueryStringParseError>,
         T::Params: for<'b> TryFrom<(&'b str, SortOrder, T::Params),
                                     Error = QueryStringParseError>,
-        T::Attrs: for<'b> From<(T, &'b T::Params)>,
+        T::Attrs: for<'b> From<(T, &'b T::Params)> + 'static,
         <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static;
 }
 
@@ -243,12 +240,11 @@ impl PatchRouter for Router {
         <T::Context as FromRequest>::Error: 'static,
         T::JsonApiIdType: FromStr,
         Status: for<'b> From<&'b T::Error>,
-        T::Resource: Serialize + Deserialize + Clone + 'static + for<'b> From<(T, &'b T::Params)>,
         T::Params: for<'b> TryFrom<(&'b str, Vec<&'b str>, T::Params),
                                     Error = QueryStringParseError>,
         T::Params: for<'b> TryFrom<(&'b str, SortOrder, T::Params),
                                     Error = QueryStringParseError>,
-        T::Attrs: for<'b> From<(T, &'b T::Params)>,
+        T::Attrs: for<'b> From<(T, &'b T::Params)> + 'static,
         <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static {
 
         self.patch(format!("/{}/:id", T::resource_name()),

--- a/rustiful/src/object.rs
+++ b/rustiful/src/object.rs
@@ -1,4 +1,6 @@
+use data::JsonApiData;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonApiObject<T> {
-    pub data: T,
+    pub data: JsonApiData<T>
 }

--- a/rustiful/src/request/get.rs
+++ b/rustiful/src/request/get.rs
@@ -23,7 +23,7 @@ autoimpl! {
         <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
         fn get(id: &'a str, query: &'a str, ctx: T::Context)
-        -> Result<JsonApiObject<JsonApiData<T::Attrs>>, RequestError<T::Error>> {
+        -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error>> {
             match T::from_str(query) {
                 Ok(params) => {
                     match <T::JsonApiIdType>::from_str(id) {

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -14,8 +14,8 @@ autoimpl! {
               T::Attrs: for<'b> From<(T, &'b T::Params)>,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
-        fn patch(id: &'a str, json: T::Resource, ctx: T::Context)
-        -> Result<JsonApiObject<JsonApiData<T::Attrs>>, RequestError<T::Error>> {
+        fn patch(id: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context)
+        -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error>> {
             match <T::JsonApiIdType>::from_str(id) {
                 Ok(typed_id) => {
                     match <T as JsonPatch>::update(typed_id, json, ctx) {

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -11,8 +11,8 @@ autoimpl! {
               Status: for<'b> From<&'b T::Error>,
               T::Attrs: for<'b> From<(T, &'b T::Params)>
     {
-        fn create(json: T::Resource, ctx: T::Context) ->
-            Result<JsonApiObject<JsonApiData<T::Attrs>>, RequestError<T::Error>> {
+        fn create(json: JsonApiData<T::Attrs>, ctx: T::Context) ->
+        Result<JsonApiObject<T::Attrs>, RequestError<T::Error>> {
             match <T as JsonPost>::create(json, ctx) {
                 Ok(result) => Ok(JsonApiObject::<_> { data: result.into() }),
                 Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -5,6 +5,7 @@ use params::JsonApiResource;
 use status::Status;
 use std;
 use to_json::ToJson;
+use data::JsonApiData;
 
 pub trait JsonGet
     where Self: JsonApiResource
@@ -25,7 +26,7 @@ pub trait JsonPost
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
-    fn create(json: Self::Resource, ctx: Self::Context) -> Result<Self, Self::Error>
+    fn create(json: JsonApiData<Self::Attrs>, ctx: Self::Context) -> Result<Self, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
@@ -36,7 +37,7 @@ pub trait JsonPatch
     type Context: FromRequest;
 
     fn update(id: Self::JsonApiIdType,
-              json: Self::Resource,
+              json: JsonApiData<Self::Attrs>,
               ctx: Self::Context)
               -> Result<Self, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;

--- a/rustiful/src/to_json.rs
+++ b/rustiful/src/to_json.rs
@@ -3,7 +3,7 @@ use serde::de::Deserialize;
 use serde::ser::Serialize;
 
 pub trait ToJson {
-    type Attrs: Serialize + Deserialize;
+    type Attrs: Clone + Serialize + Deserialize;
     type Resource: Clone + Serialize + Deserialize;
 
     fn id(&self) -> JsonApiId;


### PR DESCRIPTION
* Add an implementation of Display for JsonApiId, in order to make
testing easier
* JsonApiObject data type is now JsonApiData<T> instead of just T
* Add a builder converting a JsonApiData type to a corresponding
JsonApiResource
* Add tests that exercises POST and PATCH (this doesn't work 100% right
now)