### PR TITLE
Use a router builder instead of extension methods

### DIFF
--- a/rustiful-test/Cargo.toml
+++ b/rustiful-test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Blake Pettersson <blake.pettersson@gmail.com>"]
 
 [dependencies]
-rustiful = { path = "../rustiful", features = ["uuid", "iron", "router", "bodyparser"] }
+rustiful = { path = "../rustiful", features = ["uuid"] }
 rustiful-derive = { path = "../rustiful-derive" }
 serde = "1.0"
 serde_derive = "1.0"
@@ -15,16 +15,12 @@ diesel = { version = "0.12.0", features = ["sqlite"] }
 diesel_codegen = { version = "0.12.0", features = ["sqlite"] }
 dotenv = "0.8.0"
 iron = "0.5.*"
-router = "0.5.*"
 iron-test = "0.5.*"
-clippy = {version = "0.0.123", optional = true}
+clippy = {version = "0.0.123", optional = true }
 r2d2 = { version = "0.7" }
 r2d2-diesel = { version = "0.12" }
 lazy_static = "0.2"
-bodyparser = { version = "0.7.*" }
-persistent = "0.3.0"
 
 [features]
 default = []
 dev = ["clippy"]
-

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -5,13 +5,11 @@ extern crate serde_derive;
 extern crate rustiful_derive;
 
 extern crate iron;
-extern crate router;
 extern crate iron_test;
 extern crate uuid;
 extern crate rustiful;
 extern crate serde_json;
 
-use self::router::Router;
 use iron::Headers;
 use iron::headers::ContentType;
 use iron::prelude::*;
@@ -29,13 +27,10 @@ use rustiful::JsonIndex;
 use rustiful::JsonPost;
 
 use rustiful::ToJson;
-use rustiful::iron::DeleteRouter;
-use rustiful::iron::GetRouter;
-use rustiful::iron::IndexRouter;
-use rustiful::iron::PostRouter;
 use rustiful::status::Status;
 use std::error::Error;
 use std::fmt::Display;
+use rustiful::iron::JsonApiRouterBuilder;
 use std::fmt::Formatter;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
@@ -139,13 +134,13 @@ impl JsonPost for Foo {
     }
 }
 
-fn app_router() -> Router {
-    let mut router = Router::new();
+fn app_router() -> iron::Chain {
+    let mut router = JsonApiRouterBuilder::default();
     router.jsonapi_get::<Foo>();
     router.jsonapi_post::<Foo>();
     router.jsonapi_index::<Foo>();
     router.jsonapi_delete::<Foo>();
-    router
+    router.build()
 }
 
 #[test]

--- a/rustiful/Cargo.toml
+++ b/rustiful/Cargo.toml
@@ -16,11 +16,12 @@ autoimpl = "0.1"
 router = { version = "0.5.*", optional = true }
 iron = { version = "0.5.*", optional = true }
 bodyparser = { version = "0.7.*", optional = true }
-clippy = {version = "0.0.123", optional = true}
+clippy = {version = "0.0.123", optional = true }
+persistent = {version = "0.3.0", optional = true }
 
 [features]
-default = ["iron", "router", "bodyparser"]
-dev = ["clippy", "iron", "router", "bodyparser"]
+default = ["iron", "router", "bodyparser", "persistent"]
+dev = ["clippy", "iron", "router", "bodyparser", "persistent"]
 
 [dev-dependencies]
 iron = "0.5.*"


### PR DESCRIPTION
Remove all the extension methods that were previously used to setup the
routes for the Json* types. Instead we'll use a wrapper type around the
Router, since partially the code is much simpler and partially we need
to setup the body parser, and it's simpler to have the setup in the
router builder than it is for a user to have to set that up on their
own.