### PR TITLE
Ensure that id is set in builder

### DIFF
--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -74,6 +74,7 @@ pub fn expand_json_api_models(name: &syn::Ident,
 
     let jsonapi_builder_id_attr = quote!(pub #json_api_id_ident: #json_api_id_ty);
     let jsonapi_builder_id = quote!(#json_api_id_ident: self.#json_api_id_ident);
+    let jsonapi_builder_id_setter = quote!(new.#json_api_id_ident = model.#json_api_id_ident;);
 
     let mod_name = Ident::new(format!("__json_{}", lower_case_name_as_str));
 
@@ -116,6 +117,7 @@ pub fn expand_json_api_models(name: &syn::Ident,
 
                 pub fn new(model: #name) -> Self {
                     let mut new:Self = Default::default();
+                    #jsonapi_builder_id_setter
                     #(#jsonapi_setter_fields)*
                     new
                 }

--- a/rustiful-test/tests/service_tests.rs
+++ b/rustiful-test/tests/service_tests.rs
@@ -29,6 +29,7 @@ use r2d2::Pool;
 use r2d2::PooledConnection;
 use r2d2_diesel::ConnectionManager;
 use rustiful::*;
+use rustiful::TryFrom;
 use rustiful::SortOrder::*;
 use rustiful::status::Status;
 use std::env;
@@ -250,4 +251,20 @@ fn test_crud() {
     assert_eq!(updated.body, Some("1".to_string()));
     assert_eq!(updated.title, "3".to_string());
     assert_eq!(updated.published, true);
+}
+
+#[test]
+fn test_setting_of_id_in_try_from() {
+    let json_attrs = <Test as ToJson>::Attrs::new(Some("3".to_string()), None, None);
+    let json = JsonApiData::new(Some(JsonApiId::from("1".to_string())), "".to_string(), json_attrs);
+    let test = Test {
+        id: "1".to_string(),
+        title: "foo".to_string(),
+        body: None,
+        published: false
+    };
+
+    let expected_id = test.id.clone();
+    let result: Test = (test, json).try_into().unwrap();
+    assert_eq!(expected_id, result.id)
 }


### PR DESCRIPTION
When converting from `(T, T::Resource)` to `T` with `TryFrom`, ensure
that the id is actually set in the newly constructed `T`.