### PR TITLE
Disallow Option types as an id type

### DIFF
--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -178,25 +178,12 @@ pub fn expand_json_api_models(name: &syn::Ident,
 }
 
 fn generate_option_method(ident: &syn::Ident, ty: &Ty, generate_serde_attribute: bool) -> Tokens {
-    if is_option_ty(ty) && generate_serde_attribute {
+    if util::is_option_ty(ty) && generate_serde_attribute {
         quote! {
                 #[serde(default, deserialize_with = "rustiful::json_option::some_option")]
                 pub #ident: Option<#ty>
         }
     } else {
         quote!(pub #ident: Option<#ty>)
-    }
-}
-
-fn is_option_ty(ty: &Ty) -> bool {
-    let option_ident = Ident::new("Option");
-    match *ty {
-        Ty::Path(_, ref path) => {
-            path.segments
-                .first()
-                .map(|s| s.ident == option_ident)
-                .unwrap_or(false)
-        }
-        _ => false,
     }
 }

--- a/rustiful-derive/src/util.rs
+++ b/rustiful-derive/src/util.rs
@@ -1,9 +1,16 @@
+use quote::Tokens;
 use syn::Body;
 use syn::Field;
 use syn::Ident;
+use syn::Ty;
 use syn::VariantData;
-use quote::Tokens;
 
+/// This is a wrapper for a field, with its ident.
+///
+/// `Field::ident` returns an `Option<Ident>`, but since we know that there will always be an
+/// `Ident` for a given field (since we disallow anything that's not a struct with fields),
+/// we return the field and ident in this wrapper. This saves us from having to do any cloning
+/// dances when we want to do something with the ident.
 pub struct JsonApiField {
     pub field: Field,
     pub ident: Ident,
@@ -36,6 +43,11 @@ pub fn get_attrs_and_id(body: Body) -> (JsonApiField, Vec<JsonApiField>) {
 
             // This seems to be the only way to get the first element by value in stable Rust.
             for json_api_id in id {
+                if is_option_ty(&json_api_id.field.ty) {
+                    panic!("Option types are not supported as an id for {}.",
+                           &json_api_id.ident);
+                }
+
                 return (json_api_id, attrs);
             }
 
@@ -45,8 +57,21 @@ pub fn get_attrs_and_id(body: Body) -> (JsonApiField, Vec<JsonApiField>) {
     }
 }
 
+pub fn is_option_ty(ty: &Ty) -> bool {
+    let option_ident = Ident::new("Option");
+    match *ty {
+        Ty::Path(_, ref path) => {
+            path.segments
+                .first()
+                .map(|s| s.ident == option_ident)
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
 #[cfg(feature = "uuid")]
-/// This method is used to conditionally add the uuid crate to the generated types. . If the feature
+/// This method is used to conditionally add the uuid crate to the generated types. If the feature
 /// "uuid" is set, then this will add the crate along with a use declaration of `Uuid`.
 pub fn get_uuid_tokens() -> Tokens {
     quote! {
@@ -59,5 +84,5 @@ pub fn get_uuid_tokens() -> Tokens {
 /// This method is used to conditionally add the uuid crate to the generated types. If the feature
 /// "uuid" is not set, then this does nothing.
 pub fn get_uuid_tokens() -> Tokens {
-    quote! {}
+    quote!{}
 }


### PR DESCRIPTION
When converting a struct to its JSON representation, we would want to
ensure that we do not get any null ids. The way to go here is to
disallow Options to be used as a JsonApi id type.