### PR TITLE
Add `TryFrom` implementation

### DIFF
--- a/rustiful-derive/src/builder.rs
+++ b/rustiful-derive/src/builder.rs
@@ -1,0 +1,97 @@
+use quote::Tokens;
+use util::JsonApiField;
+use syn::Ident;
+use util;
+use json::generate_option_method;
+extern crate inflector;
+
+use self::inflector::Inflector;
+
+pub fn expand_json_api_builders(name: &Ident,
+                                &(ref id, ref fields): &(JsonApiField, Vec<JsonApiField>))
+                                -> Tokens {
+    let json_api_id_ty = &id.field.ty;
+    let json_api_id_ident = &id.ident;
+    let lower_case_name = Ident::new(name.to_string().to_snake_case());
+    let lower_case_name_as_str = lower_case_name.to_string();
+
+    let mut jsonapi_attrs: Vec<_> = Vec::with_capacity(fields.len());
+    let mut jsonapi_builder_fields: Vec<_> = Vec::with_capacity(fields.len());
+    let mut jsonapi_builder_attrs: Vec<_> = Vec::with_capacity(fields.len());
+    let mut jsonapi_setter_fields: Vec<_> = Vec::with_capacity(fields.len());
+    let mut jsonapi_builder_methods: Vec<_> = Vec::with_capacity(fields.len());
+    let mut jsonapi_builder_setter: Vec<_> = Vec::with_capacity(fields.len());
+
+    for field in fields {
+        let ty = &field.field.ty;
+        let ident = &field.ident;
+        let ident_string = &ident.to_string();
+
+        jsonapi_attrs.push(generate_option_method(ident, ty, true));
+        jsonapi_builder_attrs.push(generate_option_method(ident, ty, false));
+
+        jsonapi_builder_fields.push(quote! {
+            #ident: self.#ident.ok_or(format!("#{} must be initialized", #ident_string))?
+        });
+        jsonapi_setter_fields.push(quote! { new.#ident = Some(model.#ident); });
+        jsonapi_builder_methods.push(quote! {
+            pub fn #ident<VALUE: Into<#ty>>(&mut self, value: VALUE) -> &mut Self {
+                let mut new = self;
+                new.#ident = Some(value.into());
+                new
+            }
+        });
+
+        jsonapi_builder_setter.push(quote! {
+            updated_attrs.attributes.#ident.map(|v| builder.#ident(v));
+        });
+    }
+
+    let jsonapi_builder_id_attr = quote!(pub #json_api_id_ident: #json_api_id_ty);
+    let jsonapi_builder_id = quote!(#json_api_id_ident: self.#json_api_id_ident);
+    let jsonapi_builder_id_setter = quote!(new.#json_api_id_ident = model.#json_api_id_ident;);
+
+    let mod_name = Ident::new(format!("__builder_{}", lower_case_name_as_str));
+
+    let uuid = util::get_uuid_tokens();
+
+    quote! {
+        mod #mod_name {
+            #uuid
+
+            use super::#name;
+            use rustiful::ToBuilder;
+            use rustiful::JsonApiBuilder;
+
+            #[derive(Debug, Default)]
+            pub struct Builder {
+                #jsonapi_builder_id_attr,
+                #(#jsonapi_builder_attrs),*
+            }
+
+            impl Builder {
+                #(#jsonapi_builder_methods)*
+            }
+
+            impl JsonApiBuilder<#name> for Builder {
+                fn new(model: #name) -> Self {
+                    let mut new:Self = Default::default();
+                    #jsonapi_builder_id_setter
+                    #(#jsonapi_setter_fields)*
+                    new
+                }
+
+                fn build(self) -> Result<#name, String> {
+                    Ok(#name {
+                        #jsonapi_builder_id,
+                        #(#jsonapi_builder_fields),*
+                    })
+                }
+            }
+
+            impl ToBuilder for #name {
+                type Builder = Builder;
+            }
+        }
+    }
+}

--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -11,58 +11,32 @@ use util::JsonApiField;
 pub fn expand_json_api_models(name: &syn::Ident,
                               &(ref id, ref fields): &(JsonApiField, Vec<JsonApiField>))
                               -> Tokens {
-    let json_api_id_ty = &id.field.ty;
     let json_api_id_ident = &id.ident;
-    let generated_jsonapi_attrs = Ident::new(format!("__{}{}", name, "JsonApiAttrs"));
 
     let lower_case_name = Ident::new(name.to_string().to_snake_case());
     let lower_case_name_as_str = lower_case_name.to_string();
-
-    // Used in the quasi-quotation below as `#generated_params_type_name`;
-    // append name + `Params` to the new struct name
-    let generated_params_type_name = Ident::new(format!("__{}{}", name, "Params"));
 
     let mut jsonapi_attrs: Vec<_> = Vec::with_capacity(fields.len());
     let mut filtered_option_vars: Vec<_> = Vec::with_capacity(fields.len());
     let mut filtered_option_fields: Vec<_> = Vec::with_capacity(fields.len());
     let mut attr_constructor_fields: Vec<_> = Vec::with_capacity(fields.len());
-
-
     let mut filtered_option_cases: Vec<_> = Vec::with_capacity(fields.len());
-    let mut jsonapi_builder_fields: Vec<_> = Vec::with_capacity(fields.len());
-    let mut jsonapi_builder_attrs: Vec<_> = Vec::with_capacity(fields.len());
-    let mut jsonapi_setter_fields: Vec<_> = Vec::with_capacity(fields.len());
-    let mut jsonapi_builder_methods: Vec<_> = Vec::with_capacity(fields.len());
-    let mut jsonapi_builder_setter: Vec<_> = Vec::with_capacity(fields.len());
     let mut attr_constructor_args: Vec<_> = Vec::with_capacity(fields.len());
+    let mut jsonapi_builder_setter: Vec<_> = Vec::with_capacity(fields.len());
 
     for field in fields {
         let ty = &field.field.ty;
         let ident = &field.ident;
-        let ident_string = &ident.to_string();
 
         jsonapi_attrs.push(generate_option_method(ident, ty, true));
-        jsonapi_builder_attrs.push(generate_option_method(ident, ty, false));
 
         filtered_option_vars.push(quote!(let mut #ident = Some(model.#ident);));
 
-        let fields = quote!(#ident: #ident);
-        filtered_option_fields.push(fields.clone());
-        attr_constructor_fields.push(fields);
+        filtered_option_fields.push(quote!(#ident));
+        attr_constructor_fields.push(quote!(#ident: #ident));
 
         filtered_option_cases.push(quote! {
             &super::#lower_case_name::field::#ident => #ident = None
-        });
-        jsonapi_builder_fields.push(quote! {
-            #ident: self.#ident.ok_or(format!("#{} must be initialized", #ident_string))?
-        });
-        jsonapi_setter_fields.push(quote! { new.#ident = Some(model.#ident); });
-        jsonapi_builder_methods.push(quote! {
-            pub fn #ident<VALUE: Into<#ty>>(&mut self, value: VALUE) -> &mut Self {
-                let mut new = self;
-                new.#ident = Some(value.into());
-                new
-            }
         });
 
         jsonapi_builder_setter.push(quote! {
@@ -72,10 +46,6 @@ pub fn expand_json_api_models(name: &syn::Ident,
         attr_constructor_args.push(quote! { #ident: Option<#ty> });
     }
 
-    let jsonapi_builder_id_attr = quote!(pub #json_api_id_ident: #json_api_id_ty);
-    let jsonapi_builder_id = quote!(#json_api_id_ident: self.#json_api_id_ident);
-    let jsonapi_builder_id_setter = quote!(new.#json_api_id_ident = model.#json_api_id_ident;);
-
     let mod_name = Ident::new(format!("__json_{}", lower_case_name_as_str));
 
     let uuid = util::get_uuid_tokens();
@@ -83,66 +53,53 @@ pub fn expand_json_api_models(name: &syn::Ident,
     quote! {
         mod #mod_name {
             #uuid
+
             extern crate rustiful;
 
             use super::#name;
-            use super::#lower_case_name::#generated_params_type_name;
-
             use rustiful::ToJson;
             use rustiful::TryFrom;
+            use rustiful::TryInto;
+            use rustiful::ToBuilder;
             use rustiful::JsonApiData;
+            use rustiful::JsonApiBuilder;
+            use rustiful::JsonApiResource;
 
             #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-            pub struct #generated_jsonapi_attrs {
+            pub struct JsonApiAttributes {
                 #(#jsonapi_attrs),*
             }
 
-            impl #generated_jsonapi_attrs {
-                pub fn new(#(#attr_constructor_args),*) -> #generated_jsonapi_attrs {
-                    #generated_jsonapi_attrs {
+            impl JsonApiAttributes {
+                pub fn new(#(#attr_constructor_args),*) -> JsonApiAttributes {
+                    JsonApiAttributes {
                         #(#attr_constructor_fields),*
                     }
                 }
             }
 
-            #[derive(Debug, Default, Clone, PartialEq, Eq)]
-            struct Builder {
-                #jsonapi_builder_id_attr,
-                #(#jsonapi_builder_attrs),*
-            }
-
-            impl Builder {
-                #(#jsonapi_builder_methods)*
-
-                pub fn new(model: #name) -> Self {
-                    let mut new:Self = Default::default();
-                    #jsonapi_builder_id_setter
-                    #(#jsonapi_setter_fields)*
-                    new
-                }
-
-                pub fn build(self) -> Result<#name, String> {
-                    Ok(#name {
-                        #jsonapi_builder_id,
-                        #(#jsonapi_builder_fields),*
-                    })
-                }
-            }
-
-            impl TryFrom<(#name, JsonApiData<#generated_jsonapi_attrs>)> for #name {
+            impl TryFrom<JsonApiData<JsonApiAttributes>> for #name {
                 type Error = String;
 
-                fn try_from((model, updated_attrs): (#name, JsonApiData<#generated_jsonapi_attrs>))
+                fn try_from(json: JsonApiData<JsonApiAttributes>) -> Result<Self, Self::Error> {
+                    (Default::default(), json).try_into()
+                }
+            }
+
+            impl TryFrom<(#name, JsonApiData<JsonApiAttributes>)> for #name {
+                type Error = String;
+
+                fn try_from((model, updated_attrs): (#name, JsonApiData<JsonApiAttributes>))
                 -> Result<Self, Self::Error> {
-                    let mut builder = Builder::new(model);
+                    let mut builder = <#name as ToBuilder>::Builder::new(model);
                     #(#jsonapi_builder_setter)*
                     builder.build()
                 }
             }
 
             impl ToJson for #name {
-                type Attrs = #generated_jsonapi_attrs;
-                type Resource = JsonApiData<#generated_jsonapi_attrs>;
+                type Attrs = JsonApiAttributes;
+                type Resource = JsonApiData<JsonApiAttributes>;
 
                 fn id(&self) -> String {
                     self.#json_api_id_ident.to_string()
@@ -153,8 +110,16 @@ pub fn expand_json_api_models(name: &syn::Ident,
                 }
             }
 
-            impl <'a> From<(#name, &'a #generated_params_type_name)> for #generated_jsonapi_attrs {
-                fn from((model, params): (#name, &'a #generated_params_type_name)) -> Self {
+            /// Converts a `(T, T::Params)` to a `JsonApiAttributes`.
+            ///
+            /// If `params.filter.fields` is empty, this will set each field of the
+            /// `JsonApiAttributes` to whatever value that the `model` field has.
+            ///
+            /// However, `params.filter.fields` is not empty, all fields that are not present
+            /// in `params.filter.fields` will be set to `None.` With this, we only serialize the
+            /// fields that we want to display when fetching an object.
+            impl <'a> From<(#name, &'a <#name as JsonApiResource>::Params)> for JsonApiAttributes {
+                fn from((model, params): (#name, &'a <#name as JsonApiResource>::Params)) -> Self {
                     #(#filtered_option_vars)*
 
                     let fields = &params.filter.fields;
@@ -168,16 +133,14 @@ pub fn expand_json_api_models(name: &syn::Ident,
                         }
                     }
 
-                    #generated_jsonapi_attrs {
-                        #(#filtered_option_fields),*
-                    }
+                    JsonApiAttributes::new(#(#filtered_option_fields),*)
                 }
             }
         }
     }
 }
 
-fn generate_option_method(ident: &syn::Ident, ty: &Ty, generate_serde_attribute: bool) -> Tokens {
+pub fn generate_option_method(ident: &syn::Ident, ty: &Ty, generate_serde_attribute: bool) -> Tokens {
     if util::is_option_ty(ty) && generate_serde_attribute {
         quote! {
                 #[serde(default, deserialize_with = "rustiful::json_option::some_option")]

--- a/rustiful-derive/src/lib.rs
+++ b/rustiful-derive/src/lib.rs
@@ -15,6 +15,7 @@ extern crate proc_macro;
 mod util;
 mod json;
 mod params;
+mod builder;
 
 use proc_macro::TokenStream;
 use syn::DeriveInput;
@@ -27,7 +28,8 @@ pub fn generate_json_api(input: TokenStream) -> TokenStream {
     let pair = util::get_attrs_and_id(source.body);
 
     // Build the output
-    let mut expanded = params::expand_json_api_fields(name, &source.attrs, &pair);
+    let mut expanded = builder::expand_json_api_builders(name, &pair);
+    expanded.append(params::expand_json_api_fields(name, &source.attrs, &pair).as_str());
     expanded.append(json::expand_json_api_models(name, &pair).as_str());
 
     // Return the generated impl as a TokenStream
@@ -40,6 +42,14 @@ pub fn generate_json_api_models(input: TokenStream) -> TokenStream {
     let name = &source.ident;
     let pair = util::get_attrs_and_id(source.body);
     json::expand_json_api_models(name, &pair).parse().unwrap()
+}
+
+#[proc_macro_derive(JsonApiBuilder, attributes(JsonApiId))]
+pub fn generate_json_api_builders(input: TokenStream) -> TokenStream {
+    let source = parse_derive_input(&input);
+    let name = &source.ident;
+    let pair = util::get_attrs_and_id(source.body);
+    builder::expand_json_api_builders(name, &pair).parse().unwrap()
 }
 
 #[proc_macro_derive(JsonApiParams)]

--- a/rustiful-derive/src/params.rs
+++ b/rustiful-derive/src/params.rs
@@ -22,10 +22,6 @@ pub fn expand_json_api_fields(name: &syn::Ident,
     let lower_cased_ident = Ident::new(lower_case_name);
     let pluralized_name = json_name.to_plural().to_kebab_case();
 
-    // Used in the quasi-quotation below as `#params_name`;
-    // append name + `Params` to the new struct name
-    let params_name = Ident::new(format!("__{}{}", name, "Params"));
-
     let mut option_fields: Vec<_> = Vec::with_capacity(fields.len());
     let option_fields_len = fields.len();
 
@@ -97,13 +93,13 @@ pub fn expand_json_api_fields(name: &syn::Ident,
             }
 
             #[derive(Debug, PartialEq, Eq, Clone, Default)]
-            pub struct #params_name {
+            pub struct JsonApiParams {
                 pub filter: Filter,
                 pub sort: Sort,
                 pub query_params: HashMap<String, String>
             }
 
-            impl TypedParams<sort, field> for #params_name {
+            impl TypedParams<sort, field> for JsonApiParams {
                 fn filter(&mut self) -> &mut Vec<field> {
                     &mut self.filter.fields
                 }
@@ -118,10 +114,10 @@ pub fn expand_json_api_fields(name: &syn::Ident,
             }
 
             /// Parses the sort query parameter.
-            impl<'a> TryFrom<(&'a str, SortOrder, #params_name)> for #params_name {
+            impl<'a> TryFrom<(&'a str, SortOrder, JsonApiParams)> for JsonApiParams {
                 type Error = QueryStringParseError;
 
-                fn try_from((field, order, mut params): (&'a str, SortOrder, #params_name))
+                fn try_from((field, order, mut params): (&'a str, SortOrder, JsonApiParams))
                 -> Result<Self, Self::Error> {
                     //TODO: Add duplicate sort checks? (i.e sort=foo,foo,-foo)?
                     match field {
@@ -134,10 +130,10 @@ pub fn expand_json_api_fields(name: &syn::Ident,
             }
 
             /// Parses the field query parameter(s).
-            impl<'a> TryFrom<(&'a str, Vec<&'a str>, #params_name)> for #params_name {
+            impl<'a> TryFrom<(&'a str, Vec<&'a str>, JsonApiParams)> for JsonApiParams {
                 type Error = QueryStringParseError;
 
-                fn try_from((model, fields, mut params): (&'a str, Vec<&'a str>, #params_name))
+                fn try_from((model, fields, mut params): (&'a str, Vec<&'a str>, JsonApiParams))
                 -> Result<Self, Self::Error> {
                     match model {
                         #json_name => {
@@ -164,7 +160,7 @@ pub fn expand_json_api_fields(name: &syn::Ident,
 
             impl JsonApiResource for #name {
                 type JsonApiIdType = #json_api_id_ty;
-                type Params = #params_name;
+                type Params = JsonApiParams;
                 type SortField = sort;
                 type FilterField = field;
 

--- a/rustiful-test/tests/lib.rs
+++ b/rustiful-test/tests/lib.rs
@@ -12,7 +12,7 @@ use rustiful::QueryStringParseError;
 use rustiful::SortOrder::*;
 use rustiful::ToJson;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
 struct Foo {
     #[JsonApiId]
     bar: i32,
@@ -20,7 +20,7 @@ struct Foo {
     abc: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
 #[serde(rename = "renamed")]
 struct Bar {
     id: String,

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -27,13 +27,13 @@ use rustiful::JsonIndex;
 use rustiful::JsonPost;
 
 use rustiful::ToJson;
+use rustiful::iron::JsonApiRouterBuilder;
 use rustiful::status::Status;
 use std::error::Error;
 use std::fmt::Display;
-use rustiful::iron::JsonApiRouterBuilder;
 use std::fmt::Formatter;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
 struct Foo {
     id: String,
     title: String,

--- a/rustiful/src/builder.rs
+++ b/rustiful/src/builder.rs
@@ -1,0 +1,15 @@
+/// A trait for implementing a builder for any `Default` type.
+///
+/// The implementing type is generated in jsonapi-derive.
+pub trait JsonApiBuilder<T> where T: Default {
+    fn new(model: T) -> Self;
+
+    fn build(self) -> Result<T, String>;
+}
+
+/// A trait for setting a `JsonApiBuilder<Self>` on any type that implements `Default`.
+///
+/// This is used in order to access the builder easily after generating the builder.
+pub trait ToBuilder where Self : Sized + Default {
+    type Builder: JsonApiBuilder<Self>;
+}

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -36,6 +36,9 @@ pub use object::*;
 mod error;
 pub use error::*;
 
+mod builder;
+pub use builder::*;
+
 mod request;
 
 #[cfg(feature = "iron")]


### PR DESCRIPTION
This commit adds a `TryFrom` implementation for any type that implements
`ToJson`. This converts a `JsonApiData<T::Attrs>` to a `T`, and means
that we can get rid of the manual boilerplate converting a
`JsonApiData<T::Attrs>` to a `T`.

In order to do this, we now enforce that any type implementing
`JsonApiBuilder<T>` also has to implement `Default`.

This also moves the builder logic in rustiful-derive to its own
module, instead of having it within the `json` module.