### PR TITLE
Fix for Travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ rust:
   - beta
   - nightly
 
+before_install:
+    - cargo install diesel_cli || true
 script:
-    - cargo install diesel_cli
     - cd rustiful-test && diesel migration run && cd ..
     - cargo build --all --verbose
     # Let the SQLite tests run sequentially

--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -20,6 +20,11 @@ impl<T> JsonApiData<T> {
             attributes: attrs,
         }
     }
+
+    /// Check if there is an id present.
+    pub fn has_id(&self) -> bool {
+        self.id.is_some()
+    }
 }
 
 


### PR DESCRIPTION
This fixes an error in Travis where converting from a `Self::Resource`
to a `Self` will set a client supplied id to a default value, instead of
the actual id.

This commit adds a check to see whether an id has been set on the json
resource, and takes the id into account when doing the conversion.