### PR TITLE
Bump diesel version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ members = [
     "rustiful-derive",
     "rustiful-test",
 ]
-
-[replace]
-"diesel:0.12.1" = { git = "https://github.com/diesel-rs/diesel", features = ["postgres", "uuid"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,22 +4,17 @@ version = "0.1.0"
 authors = ["Blake Pettersson <blake.pettersson@gmail.com>"]
 
 [dependencies]
-rustiful = { path = "../rustiful", features = ["uuid"] }
+rustiful = { path = "../rustiful", features = ["uuid", "iron"] }
 rustiful-derive = { path = "../rustiful-derive", features = ["uuid"] }
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
 dotenv = "0.8"
 iron = "0.5"
 r2d2 = "0.7"
 lazy_static = "0.2"
-r2d2-diesel = "0.12"
-
-# replace with "diesel = { git = "https://github.com/diesel-rs/diesel", features = ["postgres", "uuid"] }
-# since Diesel 0.12.1 uses an older version of uuid, and will fail to compile. If you're not using uuid this doesn't
-# apply.
-diesel = { version = "0.12.1", features = ["postgres", "uuid"] }
-diesel_codegen = { version = "0.12.0", features = ["postgres"] }
+r2d2-diesel = "0.13"
+diesel = { version = "0.13", features = ["postgres", "uuid"] }
+diesel_codegen = { version = "0.13", features = ["postgres"] }
 uuid = { version = "0.5", features = ["serde", "v4"] }
 clippy = {version = "0.0.123", optional = true }
 

--- a/examples/src/db.rs
+++ b/examples/src/db.rs
@@ -23,7 +23,7 @@ impl DB {
 pub fn create_db_pool() -> Pool<ConnectionManager<PgConnection>> {
     dotenv().ok();
 
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = env::var("POSTGRES_URL").expect("POSTGRES_URL must be set");
     let config = r2d2::Config::default();
     let manager = ConnectionManager::<PgConnection>::new(database_url);
     Pool::new(config, manager).expect("Failed to create pool.")

--- a/rustiful-test/Cargo.toml
+++ b/rustiful-test/Cargo.toml
@@ -11,14 +11,14 @@ serde_derive = "1.0"
 serde_json = "1.0"
 uuid = { version = "0.5", features = ["serde", "v4"] }
 
-diesel = { version = "0.12.0", features = ["sqlite"] }
-diesel_codegen = { version = "0.12.0", features = ["sqlite"] }
-dotenv = "0.8.0"
-iron = "0.5.*"
-iron-test = "0.5.*"
+diesel = { version = "0.13", features = ["sqlite"] }
+diesel_codegen = { version = "0.13", features = ["sqlite"] }
+dotenv = "0.8"
+iron = "0.5"
+iron-test = "0.5"
 clippy = {version = "0.0.123", optional = true }
 r2d2 = { version = "0.7" }
-r2d2-diesel = { version = "0.12" }
+r2d2-diesel = { version = "0.13" }
 lazy_static = "0.2"
 
 [features]


### PR DESCRIPTION
This diesel version supports uuid 0.5, so let's use that.