### PR TITLE
Return json

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pub struct Context {}
 // Initializes a `Context` from a request.
 impl FromRequest for Context {
     type Error = MyErr;
-    fn from_request(request: &Request) -> Result<Self, Self::Error> {
+    fn from_request(request: &Request) -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         Ok(Context {})
     }
 }
@@ -117,7 +117,7 @@ impl JsonGet for Todo {
     fn find(id: String,
             _: &Self::Params,
             ctx: Self::Context)
-            -> Result<Option<Self>, Self::Error> {
+            -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error> {
         Err(MyErr("Unimplemented"))
     }
 }
@@ -126,7 +126,7 @@ impl JsonIndex for Todo {
     type Error = MyErr;
     type Context = Context;
 
-    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<Self>, Self::Error> {
+    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error> {
         Err(MyErr("Unimplemented"))
     }
 }
@@ -144,7 +144,7 @@ impl JsonPost for Todo {
     type Error = MyErr;
     type Context = Context;
 
-    fn create(json: Self::Resource, ctx: Self::Context) -> Result<Self, Self::Error> {
+    fn create(json: JsonApiData<Self::Attrs>, ctx: Self::Context) -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         Err(MyErr("Unimplemented"))
     }
 }
@@ -154,9 +154,9 @@ impl JsonPatch for Todo {
     type Context = Context;
 
     fn update(id: String,
-              json: Self::Resource,
+              json: JsonApiData<Self::Attrs>,
               ctx: Self::Context)
-              -> Result<Self, Self::Error> {
+              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         Err(MyErr("Unimplemented"))              
     }
 }
@@ -214,13 +214,13 @@ impl JsonIndex for Todo {
     type Error = MyErr;
     type Context = Context;
 
-    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<Self>, Self::Error> {
+    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error> {
         Ok(vec![Todo {
                     id: "1".to_string(),
                     body: "test".to_string(),
                     title: "test".to_string(),
                     published: true
-                }])
+                }.into_json(params)])
     }
 }
 ```
@@ -261,7 +261,7 @@ impl JsonIndex for Todo {
     type Error = MyErr;
     type Context = Context;
     
-    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<Self>, Self::Error> {
+    fn find_all(params: &Self::Params, ctx: Self::Context) -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error> {
         let mut query = table.into_boxed();
 
         {

--- a/rustiful-test/tests/lib.rs
+++ b/rustiful-test/tests/lib.rs
@@ -6,6 +6,7 @@ extern crate rustiful_derive;
 
 extern crate rustiful;
 
+use rustiful::IntoJson;
 use rustiful::JsonApiData;
 use rustiful::JsonApiResource;
 use rustiful::QueryStringParseError;
@@ -48,10 +49,7 @@ fn parse_renamed_json_struct_fails_on_original_name() {
 fn parse_params_fails_on_id_param() {
     match <Bar as JsonApiResource>::from_str("fields[renamed]=id") {
         Ok(_) => assert!(false, "expected error but no error happened!"),
-        Err(e) => {
-            assert_eq!(QueryStringParseError::InvalidValue("id".to_string()),
-                       e)
-        }
+        Err(e) => assert_eq!(QueryStringParseError::InvalidValue("id".to_string()), e),
     }
 }
 
@@ -85,10 +83,7 @@ fn parse_field_that_is_not_present() {
 fn parse_fields_fails_if_query_param_is_not_valid() {
     match <Foo as JsonApiResource>::from_str("fields=body=foo") {
         Ok(_) => assert!(false, "expected error but no error happened!"),
-        Err(e) => {
-            assert_eq!(QueryStringParseError::InvalidKeyParam("".to_string()),
-                       e)
-        }
+        Err(e) => assert_eq!(QueryStringParseError::InvalidKeyParam("".to_string()), e),
     }
 }
 
@@ -108,8 +103,7 @@ fn parse_fields_fails_if_field_value_contains_field_that_does_not_exist() {
     match <Foo as JsonApiResource>::from_str("fields[foo]=non_existent") {
         Ok(_) => assert!(false, "expected error but no error happened!"),
         Err(e) => {
-            assert_eq!(QueryStringParseError::InvalidValue("non_existent"
-                           .to_string()),
+            assert_eq!(QueryStringParseError::InvalidValue("non_existent".to_string()),
                        e)
         }
     }
@@ -191,10 +185,7 @@ fn parse_query_param() {
 fn parse_sort_field_fails_on_id_param() {
     match <Foo as JsonApiResource>::from_str("sort=bar") {
         Ok(_) => assert!(false, "expected error but no error happened!"),
-        Err(e) => {
-            assert_eq!(QueryStringParseError::InvalidValue("bar".to_string()),
-                       e)
-        }
+        Err(e) => assert_eq!(QueryStringParseError::InvalidValue("bar".to_string()), e),
     }
 }
 
@@ -204,7 +195,7 @@ fn parse_sort_field_fails_on_multiple_sort_params() {
         Ok(_) => assert!(false, "expected error but no error happened!"),
         Err(e) => {
             assert_eq!(QueryStringParseError::DuplicateSortKey("foo".to_string()),
-            e)
+                       e)
         }
     }
 }
@@ -229,7 +220,7 @@ fn test_into_conversions_with_int_id() {
     };
 
     let expected_id = test.bar.to_string();
-    let result: JsonApiData<<Foo as ToJson>::Attrs> = test.into();
+    let result: JsonApiData<<Foo as ToJson>::Attrs> = test.into_json(&Default::default());
     assert_eq!(expected_id, result.id.expect("unexpected None on id!"));
     assert_eq!(2, result.attributes.foo.expect("unexpected None on foo!"));
     assert_eq!("abc".to_string(),
@@ -244,7 +235,7 @@ fn test_into_conversions_with_string_id() {
     };
 
     let expected_id = test.id.clone();
-    let result: JsonApiData<<Bar as ToJson>::Attrs> = test.into();
+    let result: JsonApiData<<Bar as ToJson>::Attrs> = test.into_json(&Default::default());
     assert_eq!(expected_id, result.id.expect("unexpected None on id!"));
     assert_eq!(1, result.attributes.bar.expect("unexpected None on bar!"));
 }

--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -11,13 +11,13 @@ pub struct JsonApiData<T> {
 }
 
 impl<T> JsonApiData<T> {
-    pub fn new<I: Into<String>>(id: Option<I>,
-                                lower_case_type: String,
-                                attrs: T)
-                                -> JsonApiData<T> {
+    pub fn new<Id: Into<String>, Type: Into<String>>(id: Option<Id>,
+                                                     lower_case_type: Type,
+                                                     attrs: T)
+                                                     -> JsonApiData<T> {
         JsonApiData {
             id: id.map(|i| i.into()),
-            lower_case_type: lower_case_type,
+            lower_case_type: lower_case_type.into(),
             attributes: attrs,
         }
     }
@@ -41,16 +41,28 @@ impl<'a, T> From<(T, &'a JsonApiParams<T::FilterField, T::SortField>)> for JsonA
     }
 }
 
-/// Converts a `T` to a `JsonApiData<T>`.
-impl<'a, T> From<T> for JsonApiData<T::Attrs>
+pub trait IntoJson<T, F, S> {
+    fn into_json<'a>(self, params: &'a JsonApiParams<F, S>) -> T;
+}
+
+impl<T> IntoJson<JsonApiData<T::Attrs>, T::FilterField, T::SortField> for T
     where T: ToJson + JsonApiResource,
-          T::Params: 'a,
           T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>
 {
-    fn from(model: T) -> Self {
-        let params: JsonApiParams<T::FilterField, T::SortField> = Default::default();
-        JsonApiData::new(Some(model.id()),
-                         model.type_name(),
-                         T::Attrs::from((model, &params)))
+    fn into_json<'a>(self,
+                     params: &'a JsonApiParams<T::FilterField, T::SortField>)
+                     -> JsonApiData<T::Attrs> {
+        (self, params).into()
+    }
+}
+
+impl<T> IntoJson<Vec<JsonApiData<T::Attrs>>, T::FilterField, T::SortField> for Vec<T>
+    where T: ToJson + JsonApiResource,
+          T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>
+{
+    fn into_json<'a>(self,
+                     params: &'a JsonApiParams<T::FilterField, T::SortField>)
+                     -> Vec<JsonApiData<T::Attrs>> {
+        self.into_iter().map(|i| (i, params).into()).collect()
     }
 }

--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -41,10 +41,14 @@ impl<'a, T> From<(T, &'a JsonApiParams<T::FilterField, T::SortField>)> for JsonA
     }
 }
 
+/// Converts `Self` into `T`. See the implementations to see what the conversions are intended for.
 pub trait IntoJson<T, F, S> {
     fn into_json<'a>(self, params: &'a JsonApiParams<F, S>) -> T;
 }
 
+/// Converts a `T` into `JsonApiData<T::Attrs>`. A wrapper for the `From` implementation where a
+/// tuple of `(T, JsonApiParams<T::FilterField, T::SortField>)` gets converted into
+/// `JsonApiData<T::Attrs>`.
 impl<T> IntoJson<JsonApiData<T::Attrs>, T::FilterField, T::SortField> for T
     where T: ToJson + JsonApiResource,
           T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>
@@ -56,6 +60,9 @@ impl<T> IntoJson<JsonApiData<T::Attrs>, T::FilterField, T::SortField> for T
     }
 }
 
+/// Converts a `Vec<T>` into `Vec<JsonApiData<T::Attrs>>`.  A wrapper for the `From` implementation
+/// where a tuple of `(T, JsonApiParams<T::FilterField, T::SortField>)` gets converted into
+/// `JsonApiData<T::Attrs>`.
 impl<T> IntoJson<Vec<JsonApiData<T::Attrs>>, T::FilterField, T::SortField> for Vec<T>
     where T: ToJson + JsonApiResource,
           T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>

--- a/rustiful/src/iron/handlers/get.rs
+++ b/rustiful/src/iron/handlers/get.rs
@@ -28,7 +28,6 @@ autoimpl! {
         Status: for<'b> From<&'b T::Error>,
         T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn get(req: &'a mut Request) -> IronResult<Response> {

--- a/rustiful/src/iron/handlers/index.rs
+++ b/rustiful/src/iron/handlers/index.rs
@@ -25,7 +25,6 @@ autoimpl! {
         T::Error: 'static,
         <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
-        T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
         T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
         <T::JsonApiIdType as FromStr>::Err: Error

--- a/rustiful/src/iron/handlers/patch.rs
+++ b/rustiful/src/iron/handlers/patch.rs
@@ -27,7 +27,7 @@ autoimpl! {
         T::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
         <T::Context as FromRequest>::Error: 'static,
-        T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)> + 'static + for<'b> Deserialize<'b>,
+        T::Attrs: 'static + for<'b> Deserialize<'b>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn patch(req: &'a mut Request) -> IronResult<Response> {

--- a/rustiful/src/iron/handlers/post.rs
+++ b/rustiful/src/iron/handlers/post.rs
@@ -26,7 +26,7 @@ autoimpl! {
         T::Error: 'static,
         <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
-        T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)> + 'static + for<'b> Deserialize<'b>,
+        T::Attrs: 'static + for<'b> Deserialize<'b>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn post(req: &'a mut Request) -> IronResult<Response> {

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -120,7 +120,9 @@ pub fn id<'a>(req: &'a Request) -> &'a str {
     let router = req.extensions
         .get::<Router>()
         .expect("Expected to get a Router from the request extensions.");
-    router.find("id").expect("No id param found in method that expects one!")
+    router
+        .find("id")
+        .expect("No id param found in method that expects one!")
 }
 
 
@@ -160,15 +162,16 @@ impl JsonApiRouterBuilder {
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-              T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
+              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
+                                              Error = QueryStringParseError>,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static,
-              <<T as JsonIndex>::Context as FromRequest>::Error: 'static,
+              <<T as JsonIndex>::Context as FromRequest>::Error: 'static
     {
 
-        self.router.get(format!("/{}", T::resource_name()),
-                        move |r: &mut Request| T::get(r),
-                        format!("index_{}", T::resource_name()));
+        self.router
+            .get(format!("/{}", T::resource_name()),
+                 move |r: &mut Request| T::get(r),
+                 format!("index_{}", T::resource_name()));
     }
 
     /// Setup a route for a struct that implements `JsonGet` and `JsonApiResource`.
@@ -178,15 +181,16 @@ impl JsonApiRouterBuilder {
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-              T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
+              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
+                                              Error = QueryStringParseError>,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static,
               <<T as JsonGet>::Context as FromRequest>::Error: 'static
     {
 
-        self.router.get(format!("/{}/:id", T::resource_name()),
-                        move |r: &mut Request| T::get(r),
-                        format!("get_{}", T::resource_name()));
+        self.router
+            .get(format!("/{}/:id", T::resource_name()),
+                 move |r: &mut Request| T::get(r),
+                 format!("get_{}", T::resource_name()));
     }
 
     /// Setup a route for a struct that implements `JsonDelete` and `JsonApiResource`.
@@ -199,11 +203,10 @@ impl JsonApiRouterBuilder {
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
 
-        self.router.delete(format!("/{}/:id", T::resource_name()),
-                           move |r: &mut Request| {
-                               <T as DeleteHandler<T>>::delete(r)
-                           },
-                           format!("delete_{}", T::resource_name()));
+        self.router
+            .delete(format!("/{}/:id", T::resource_name()),
+                    move |r: &mut Request| <T as DeleteHandler<T>>::delete(r),
+                    format!("delete_{}", T::resource_name()));
     }
 
 
@@ -213,14 +216,15 @@ impl JsonApiRouterBuilder {
               T: JsonPost + JsonApiResource + ToJson + for<'b> PostHandler<'b, T>,
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
-              T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)> + 'static + for<'b> Deserialize<'b>,
+              T::Attrs: 'static + for<'b> Deserialize<'b>,
               <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
 
-        self.router.post(format!("/{}", T::resource_name()),
-                         move |r: &mut Request| T::post(r),
-                         format!("create_{}", T::resource_name()));
+        self.router
+            .post(format!("/{}", T::resource_name()),
+                  move |r: &mut Request| T::post(r),
+                  format!("create_{}", T::resource_name()));
     }
 
     /// Setup a route for a struct that implements `JsonPatch` and `JsonApiResource`.
@@ -229,14 +233,15 @@ impl JsonApiRouterBuilder {
               T: JsonPatch + JsonApiResource + ToJson + for<'b> PatchHandler<'b, T>,
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
-              T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)> + 'static + for<'b> Deserialize<'b>,
+              T::Attrs: 'static + for<'b> Deserialize<'b>,
               <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
 
-        self.router.patch(format!("/{}/:id", T::resource_name()),
-                          move |r: &mut Request| T::patch(r),
-                          format!("update_{}", T::resource_name()));
+        self.router
+            .patch(format!("/{}/:id", T::resource_name()),
+                   move |r: &mut Request| T::patch(r),
+                   format!("update_{}", T::resource_name()));
     }
 
     /// Constructs an iron `Chain` with the routes that were previously specified in `jsonapi_get`,
@@ -272,7 +277,9 @@ mod tests {
         let resp: IronResult<Response> = req.try_into();
         let result = resp.expect("Invalid response!");
         let headers = result.headers.clone();
-        let content_type = headers.get::<ContentType>().expect("no content type found!");
+        let content_type = headers
+            .get::<ContentType>()
+            .expect("no content type found!");
         assert_eq!("application/vnd.api+json", content_type.to_string());
         let json = response::extract_body_to_string(result);
         assert_eq!("{\"foo\":\"bar\"}", json);
@@ -286,7 +293,9 @@ mod tests {
         let resp: IronResult<Response> = req.try_into();
         let result = resp.expect("Invalid response!");
         let headers = result.headers.clone();
-        let content_type = headers.get::<ContentType>().expect("no content type found!");
+        let content_type = headers
+            .get::<ContentType>()
+            .expect("no content type found!");
         assert_eq!("application/vnd.api+json", content_type.to_string());
         let json = response::extract_body_to_string(result);
         assert_eq!("", json);
@@ -300,7 +309,9 @@ mod tests {
         let resp: IronResult<Response> = req.try_into();
         let result = resp.expect("Invalid response!");
         let headers = result.headers.clone();
-        let content_type = headers.get::<ContentType>().expect("no content type found!");
+        let content_type = headers
+            .get::<ContentType>()
+            .expect("no content type found!");
         assert_eq!("application/vnd.api+json", content_type.to_string());
         let json = response::extract_body_to_string(result);
         assert_eq!("", json);
@@ -313,7 +324,9 @@ mod tests {
         let resp: IronResult<Response> = req.try_into();
         let result = resp.expect("Invalid response!");
         let headers = result.headers.clone();
-        let content_type = headers.get::<ContentType>().expect("no content type found!");
+        let content_type = headers
+            .get::<ContentType>()
+            .expect("no content type found!");
         assert_eq!("application/vnd.api+json", content_type.to_string());
         let json = response::extract_body_to_string(result);
         let expected = JsonApiErrorArray {

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -16,7 +16,6 @@ autoimpl! {
     pub trait FromIndex<'a, T> where
         T: ToJson + JsonIndex,
         Status: for<'b> From<&'b T::Error>,
-        T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
         T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
         <T::JsonApiIdType as FromStr>::Err: Error
@@ -26,12 +25,7 @@ autoimpl! {
             match T::from_str(query) {
                 Ok(params) => {
                     match T::find_all(&params, ctx) {
-                        Ok(result) => {
-                            let data: Vec<JsonApiData<T::Attrs>> = result.into_iter()
-                                .map(|e| (e, &params).into())
-                                .collect();
-                            Ok(JsonApiArray::<_> { data: data })
-                        },
+                        Ok(result) => Ok(JsonApiArray::<_> { data: result }),
                         Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
                     }
                 },

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -13,7 +13,6 @@ autoimpl! {
     pub trait FromPatch<'a, T>
         where T: JsonPatch,
               Status: for<'b> From<&'b T::Error>,
-              T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
               <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn patch(id: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context)
@@ -21,7 +20,7 @@ autoimpl! {
             match <T::JsonApiIdType>::from_str(id) {
                 Ok(typed_id) => {
                     match <T as JsonPatch>::update(typed_id, json, ctx) {
-                        Ok(result) => Ok(JsonApiObject::<_> { data: result.into() }),
+                        Ok(result) => Ok(JsonApiObject::<_> { data: result }),
                         Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
                     }
                 },

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -12,13 +12,12 @@ autoimpl! {
     pub trait FromPost<'a, T>
         where T: JsonPost,
               Status: for<'b> From<&'b T::Error>,
-              T::Attrs: for<'b> From<(T, &'b JsonApiParams<T::FilterField, T::SortField>)>,
               <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn create(json: JsonApiData<T::Attrs>, ctx: T::Context) ->
         Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
             match <T as JsonPost>::create(json, ctx) {
-                Ok(result) => Ok(JsonApiObject::<_> { data: result.into() }),
+                Ok(result) => Ok(JsonApiObject::<_> { data: result }),
                 Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
             }
         }

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -9,7 +9,7 @@ use std;
 use to_json::ToJson;
 
 pub trait JsonGet
-    where Self: JsonApiResource
+    where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;
@@ -17,7 +17,7 @@ pub trait JsonGet
     fn find(id: Self::JsonApiIdType,
             params: &JsonApiParams<Self::FilterField, Self::SortField>,
             ctx: Self::Context)
-            -> Result<Option<Self>, Self::Error>
+            -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
@@ -27,7 +27,9 @@ pub trait JsonPost
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
-    fn create(json: JsonApiData<Self::Attrs>, ctx: Self::Context) -> Result<Self, Self::Error>
+    fn create(json: JsonApiData<Self::Attrs>,
+              ctx: Self::Context)
+              -> Result<JsonApiData<Self::Attrs>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
@@ -40,19 +42,19 @@ pub trait JsonPatch
     fn update(id: Self::JsonApiIdType,
               json: JsonApiData<Self::Attrs>,
               ctx: Self::Context)
-              -> Result<Self, Self::Error>
+              -> Result<JsonApiData<Self::Attrs>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
 pub trait JsonIndex
-    where Self: JsonApiResource
+    where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
     fn find_all(params: &JsonApiParams<Self::FilterField, Self::SortField>,
                 ctx: Self::Context)
-                -> Result<Vec<Self>, Self::Error>
+                -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 


### PR DESCRIPTION
Different variations of `Self` are currently returned in the various
resource traits (JsonGet, JsonPatch etc). It is way less magical to
return JsonApiData, not least since it will be easier for a user to
customize the returned output, and it's way more clear what is actually
returned. It does get a bit awkward to use the `Into` trait directly,
especially for lists, which is why I've added an `IntoJson` trait. This
takes `self` and a parameter reference to make it easy to convert to a
JsonApiData type.