### PR TITLE
Add params to post and patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-##Introduction
+# Introduction
 
 Create [JSONAPI](http://jsonapi.org), um, APIs in Rust.
 
 Rustiful is based on [Iron](http://ironframework.io) and works with stable Rust (>=1.15).    
 
-#TODO
+## TODO
 
-This is still very much a work in progress. The API _will_ change and there's quite a few JSONAPI features that are not 
+This is still very much a work in progress. The API _will_ change and there's quite a few features that are not 
 currently implemented, including but not limited to:
 
 - [ ] `meta` information
@@ -16,13 +16,15 @@ currently implemented, including but not limited to:
 - [ ] Relationships
 - [ ] Filters
 - [ ] Pagination
+- [ ] Perhaps even [rocket](http://rocket.rs) support?
 
-# Features implemented so far
+## Features implemented so far
+
 - [x] GET/POST/PATCH/DELETE
 - [x] `sort` - This means that you can access the sort parameters in a type-safe way. 
 - [x] `fields` - This means that you can access the field parameters in a type-safe way.
 
-##Installation
+## Installation
 
 If you're using Cargo, add rustiful, serde and iron to your Cargo.toml. You'll probably want to have uuid support, 
 which can be added using the `uuid` feature.
@@ -36,7 +38,7 @@ rustiful = { version = "0.1", features = ["uuid", "iron"] }
 rustiful-derive = { version = "0.1", features = ["uuid"] }
 ```
 
-##How-to
+## How-to
 
 First off, we need to have a type that we want to represent as a JSONAPI resource. To do so we need a struct that at the 
 very least has an id field. The id field needs to either be named `id` or be annotated with a `JsonApiId` attribute. 
@@ -144,7 +146,10 @@ impl JsonPost for Todo {
     type Error = MyErr;
     type Context = Context;
 
-    fn create(json: JsonApiData<Self::Attrs>, ctx: Self::Context) -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+    fn create(json: JsonApiData<Self::Attrs>, 
+              params: &Self::Params, 
+              ctx: Self::Context) 
+              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         Err(MyErr("Unimplemented"))
     }
 }
@@ -155,6 +160,7 @@ impl JsonPatch for Todo {
 
     fn update(id: String,
               json: JsonApiData<Self::Attrs>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         Err(MyErr("Unimplemented"))              

--- a/examples/src/todo.rs
+++ b/examples/src/todo.rs
@@ -127,6 +127,7 @@ impl JsonPatch for Todo {
     /// saving it in the database.
     fn update(id: Self::JsonApiIdType,
               json: JsonApiData<Self::Attrs>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         let record = table
@@ -140,7 +141,7 @@ impl JsonPatch for Todo {
             .set(&patch)
             .execute(ctx.conn())
             .map_err(|e| MyErr::Diesel(e))?;
-        Ok(patch.into_json(&Default::default()))
+        Ok(patch.into_json(params))
     }
 }
 
@@ -166,6 +167,7 @@ impl JsonPost for Todo {
     /// an auto-generated id), then make sure that you return a record with the generated id. This
     /// is handled with the `get_result` method below.
     fn create(record: JsonApiData<Self::Attrs>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         let todo: Todo = record.try_into().map_err(|e| MyErr::UpdateError(e))?;
@@ -173,7 +175,7 @@ impl JsonPost for Todo {
         diesel::insert(&result)
             .into(table)
             .get_result::<Todo>(ctx.conn())
-            .map(|r| r.into_json(&Default::default()))
+            .map(|r| r.into_json(params))
             .map_err(|e| MyErr::Diesel(e))
     }
 }

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -130,6 +130,7 @@ impl JsonPost for Foo {
     type Context = FooService;
 
     fn create(json: JsonApiData<Self::Attrs>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         if let Some(id) = json.id {
@@ -144,7 +145,7 @@ impl JsonPost for Foo {
                    title: "test".to_string(),
                    published: true,
                }
-               .into_json(&Default::default()))
+               .into_json(params))
     }
 }
 
@@ -154,6 +155,7 @@ impl JsonPatch for Foo {
 
     fn update(id: Self::JsonApiIdType,
               json: JsonApiData<Self::Attrs>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error> {
         if let Some(id) = json.id {
@@ -168,7 +170,7 @@ impl JsonPatch for Foo {
                    title: "test".to_string(),
                    published: true,
                }
-               .into_json(&Default::default()))
+               .into_json(params))
     }
 }
 

--- a/rustiful/src/iron/handlers/get.rs
+++ b/rustiful/src/iron/handlers/get.rs
@@ -9,7 +9,6 @@ use FromRequest;
 use errors::FromRequestError;
 use errors::QueryStringParseError;
 use iron::id;
-use params::JsonApiParams;
 use request::FromGet;
 use service::JsonGet;
 use sort_order::SortOrder;

--- a/rustiful/src/iron/handlers/index.rs
+++ b/rustiful/src/iron/handlers/index.rs
@@ -8,7 +8,6 @@ use super::super::RequestResult;
 use FromRequest;
 use errors::FromRequestError;
 use errors::QueryStringParseError;
-use params::JsonApiParams;
 use request::FromIndex;
 use service::JsonIndex;
 use sort_order::SortOrder;

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -20,7 +20,6 @@ use errors::QueryStringParseError;
 use errors::RequestError;
 use iron::handlers::BodyParserError;
 use iron::router::Router;
-use params::JsonApiParams;
 use params::JsonApiResource;
 use serde::Serialize;
 use serde::de::Deserialize;
@@ -217,6 +216,9 @@ impl JsonApiRouterBuilder {
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
               T::Attrs: 'static + for<'b> Deserialize<'b>,
+              T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
+                  Error = QueryStringParseError>,
               <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
@@ -234,6 +236,9 @@ impl JsonApiRouterBuilder {
               T::Error: Send + 'static,
               T::JsonApiIdType: FromStr,
               T::Attrs: 'static + for<'b> Deserialize<'b>,
+              T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
+                  Error = QueryStringParseError>,
               <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {

--- a/rustiful/src/request/get.rs
+++ b/rustiful/src/request/get.rs
@@ -1,11 +1,9 @@
 use super::Status;
-use data::JsonApiData;
 use errors::IdParseError;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
-use params::JsonApiParams;
 use service::JsonGet;
 use sort_order::SortOrder;
 use std::error::Error;

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -4,7 +4,6 @@ use data::JsonApiData;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
-use params::JsonApiParams;
 use service::JsonIndex;
 use sort_order::SortOrder;
 use std::error::Error;

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -4,24 +4,33 @@ use errors::IdParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
-use params::JsonApiParams;
 use service::JsonPatch;
 use std::error::Error;
 use std::str::FromStr;
+use sort_order::SortOrder;
+use try_from::TryFrom;
+use errors::QueryStringParseError;
 
 autoimpl! {
     pub trait FromPatch<'a, T>
         where T: JsonPatch,
               Status: for<'b> From<&'b T::Error>,
+              T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
               <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn patch(id: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context)
+        fn patch(id: &'a str, query: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context)
         -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
             match <T::JsonApiIdType>::from_str(id) {
                 Ok(typed_id) => {
-                    match <T as JsonPatch>::update(typed_id, json, ctx) {
-                        Ok(result) => Ok(JsonApiObject::<_> { data: result }),
-                        Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
+                    match T::from_str(query) {
+                        Ok(params) => {
+                            match <T as JsonPatch>::update(typed_id, json, &params, ctx) {
+                                Ok(result) => Ok(JsonApiObject::<_> { data: result }),
+                                Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
+                            }
+                        },
+                        Err(e) => Err(RequestError::QueryStringParseError(e))
                     }
                 },
                 Err(e) => Err(RequestError::IdParseError(IdParseError(e)))

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -3,22 +3,31 @@ use data::JsonApiData;
 use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
-use params::JsonApiParams;
 use service::JsonPost;
 use std::error::Error;
 use std::str::FromStr;
+use try_from::TryFrom;
+use sort_order::SortOrder;
+use errors::QueryStringParseError;
 
 autoimpl! {
     pub trait FromPost<'a, T>
         where T: JsonPost,
               Status: for<'b> From<&'b T::Error>,
+              T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
               <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn create(json: JsonApiData<T::Attrs>, ctx: T::Context) ->
+        fn create(query: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context) ->
         Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
-            match <T as JsonPost>::create(json, ctx) {
-                Ok(result) => Ok(JsonApiObject::<_> { data: result }),
-                Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
+            match T::from_str(query) {
+                Ok(params) => {
+                    match <T as JsonPost>::create(json, &params, ctx) {
+                        Ok(result) => Ok(JsonApiObject::<_> { data: result }),
+                        Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
+                    }
+                },
+                Err(e) => Err(RequestError::QueryStringParseError(e))
             }
         }
     }

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -28,6 +28,7 @@ pub trait JsonPost
     type Context: FromRequest;
 
     fn create(json: JsonApiData<Self::Attrs>,
+              params: &JsonApiParams<Self::FilterField, Self::SortField>,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
@@ -41,6 +42,7 @@ pub trait JsonPatch
 
     fn update(id: Self::JsonApiIdType,
               json: JsonApiData<Self::Attrs>,
+              params: &JsonApiParams<Self::FilterField, Self::SortField>,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;


### PR DESCRIPTION
The JSONAPI spec states that at the very least there should be support
for sparse fieldsets when creating or updating a resource. Therefore,
let's add parameters for `JsonPost` and `JsonPatch`.

This also gives the added bonus of a more consistent API, since after
#26 we need to always pass in a parameter type when converting from `T`
to `JsonApiData`. Having some cases where we need to send in a default
value and some cases where we use the parameter that's sent in as an
argument is a bit inconsistent.