### PR TITLE
Remove associated type from ToJson

### DIFF
--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -117,7 +117,6 @@ pub fn expand_json_api_models(name: &syn::Ident,
 
             impl ToJson for #name {
                 type Attrs = JsonApiAttributes;
-                type Resource = JsonApiData<JsonApiAttributes>;
 
                 fn id(&self) -> String {
                     self.#json_api_id_ident.to_string()

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -193,7 +193,8 @@ fn parse_json_api_index_get() {
         .get::<ContentType>()
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
-    let records: JsonApiArray<<Foo as ToJson>::Resource> = serde_json::from_str(&result).unwrap();
+    let records: JsonApiArray<JsonApiData<<Foo as ToJson>::Attrs>> = serde_json::from_str(&result)
+        .unwrap();
     let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
@@ -202,8 +203,8 @@ fn parse_json_api_index_get() {
         title: "test".to_string(),
         published: true,
     };
-    let data: <Foo as ToJson>::Resource = (test, &params).into();
-    let expected: JsonApiArray<<Foo as ToJson>::Resource> = JsonApiArray { data: vec![data] };
+    let data: JsonApiData<<Foo as ToJson>::Attrs> = (test, &params).into();
+    let expected = JsonApiArray { data: vec![data] };
 
     assert_eq!(expected, records);
 }
@@ -220,7 +221,8 @@ fn parse_json_api_index_get_with_fieldset() {
         .get::<ContentType>()
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
-    let records: JsonApiArray<<Foo as ToJson>::Resource> = serde_json::from_str(&result).unwrap();
+    let records: JsonApiArray<JsonApiData<<Foo as ToJson>::Attrs>> = serde_json::from_str(&result)
+        .unwrap();
     let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
@@ -232,7 +234,7 @@ fn parse_json_api_index_get_with_fieldset() {
     let data = JsonApiData::new(Some("1"),
                                 "foo",
                                 <Foo as ToJson>::Attrs::new(Some("test".to_string()), None, None));
-    let expected: JsonApiArray<<Foo as ToJson>::Resource> = JsonApiArray { data: vec![data] };
+    let expected = JsonApiArray { data: vec![data] };
 
     assert_eq!(expected, records);
 }
@@ -253,8 +255,8 @@ fn parse_json_api_single_get() {
         title: "test".to_string(),
         published: true,
     };
-    let data: <Foo as ToJson>::Resource = (test, &params).into();
-    let expected: JsonApiObject<<Foo as ToJson>::Attrs> = JsonApiObject { data: data };
+    let data: JsonApiData<<Foo as ToJson>::Attrs> = (test, &params).into();
+    let expected = JsonApiObject { data: data };
 
     assert_eq!(expected, record);
 }

--- a/rustiful-test/tests/service_tests.rs
+++ b/rustiful-test/tests/service_tests.rs
@@ -213,20 +213,6 @@ impl JsonDelete for Test {
     }
 }
 
-
-impl From<<Test as ToJson>::Resource> for Test {
-    fn from(json: <Test as ToJson>::Resource) -> Self {
-        Test {
-            id: json.id
-                .map(|id| id.into())
-                .unwrap_or_else(|| Uuid::new_v4().to_string()),
-            title: json.attributes.title.unwrap_or("".to_string()),
-            body: json.attributes.body.unwrap_or(None),
-            published: json.attributes.published.unwrap_or(false),
-        }
-    }
-}
-
 lazy_static! {
     pub static ref DB_POOL: Pool<ConnectionManager<SqliteConnection>> = create_db_pool();
 }

--- a/rustiful/src/to_json.rs
+++ b/rustiful/src/to_json.rs
@@ -2,7 +2,6 @@ use serde::ser::Serialize;
 
 pub trait ToJson {
     type Attrs: Clone + Serialize;
-    type Resource: Clone + Serialize;
 
     fn id(&self) -> String;
 


### PR DESCRIPTION
Remove the `Resource` associated type from the `ToJson` trait, since
there's really no need for it.