### PR TITLE
Return Vec<JsonApiData<T>> in JsonApiArray::data

### DIFF
--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -193,8 +193,7 @@ fn parse_json_api_index_get() {
         .get::<ContentType>()
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
-    let records: JsonApiArray<JsonApiData<<Foo as ToJson>::Attrs>> = serde_json::from_str(&result)
-        .unwrap();
+    let records: JsonApiArray<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
     let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
@@ -221,8 +220,7 @@ fn parse_json_api_index_get_with_fieldset() {
         .get::<ContentType>()
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
-    let records: JsonApiArray<JsonApiData<<Foo as ToJson>::Attrs>> = serde_json::from_str(&result)
-        .unwrap();
+    let records: JsonApiArray<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
     let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
 
     let test = Foo {

--- a/rustiful/src/array.rs
+++ b/rustiful/src/array.rs
@@ -1,4 +1,6 @@
+use data::JsonApiData;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonApiArray<T> {
-    pub data: Vec<T>,
+    pub data: Vec<JsonApiData<T>>
 }

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -1,6 +1,5 @@
 use super::Status;
 use array::JsonApiArray;
-use data::JsonApiData;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
@@ -20,11 +19,11 @@ autoimpl! {
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn get(query: &'a str, ctx: T::Context)
-        -> Result<JsonApiArray<JsonApiData<T::Attrs>>, RequestError<T::Error, T::JsonApiIdType>> {
+        -> Result<JsonApiArray<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
             match T::from_str(query) {
                 Ok(params) => {
                     match T::find_all(&params, ctx) {
-                        Ok(result) => Ok(JsonApiArray::<_> { data: result }),
+                        Ok(result) => Ok(JsonApiArray { data: result }),
                         Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
                     }
                 },


### PR DESCRIPTION
We always want to return Vec<JsonApiData<T>> in the data field. We
already do this in practice, but to make it more clear state that data
will always return `Vec<JsonApiData<T>>`. This makes it a bit less wordy
when there's a need to declare the type of something that is a
`JsonApiArray<T>`.