### PR TITLE
Pluralize all the things

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Finally, we need to wire the resource so that it can actually be accessed over H
 ```
 
 Once we have built the chain, we add it to the Iron constructor and start the web server. The resource path is the 
-pluralized and hyphenated name of the resource type name, in lower-case (TODO: Add an attribute that can override 
-the default resource name). In the case of the example above that means that the routes are the following:
+pluralized and hyphenated name of the resource type name, in lower-case. In the case of the example above that means 
+that the routes are the following:
  
 ```
 GET /todos
@@ -246,14 +246,13 @@ This should be enough to get started; there's a more involved example using Dies
 `examples` directory of this repo.
   
 There's one more thing to show. You have full access to the `sort` and `fields` parameters via the params argument 
-(`Self::Params`). So far this is only implemented on `JsonGet` and `JsonIndex`. This is how it you could use the sort 
-parameters when using Diesel (This assumes that you have the appropriate Diesel attributes set on `Todo`).
+(`Self::Params`). So far this is only implemented on `JsonGet` and `JsonIndex`. 
 
 The `Self::Params` type is an alias for `JsonApiParams<F, S>`, which has three fields: `sort`, which gives access to the 
 sort query parameter, `fieldset` which gives access to the `fields` query parameter, and `query_params` which gives 
-access to all other query parameters. 
-   
-   
+access to all other query parameters. Here's an example when using the sort parameters with Diesel 
+(This assumes that you have the appropriate Diesel attributes set on `Todo`).
+
 ```rust
 // Rustiful
 use self::todo::sort::*;
@@ -306,7 +305,7 @@ impl JsonIndex for Todo {
                 2 => query = query.order((order_columns.remove(0), order_columns.remove(0))),
                 3 => query = query.order((order_columns.remove(0), order_columns.remove(0), order_columns.remove(0))),
                 4 => query = query.order((order_columns.remove(0), order_columns.remove(0), order_columns.remove(0), order_columns.remove(0))),
-                _ => return Err(MyErr::TooManySortColumns("too many sort columns".to_string()))
+                _ => return Err(MyErr("too many sort columns".to_string()))
             }
         }
 

--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -123,7 +123,7 @@ pub fn expand_json_api_models(name: &syn::Ident,
                 }
 
                 fn type_name(&self) -> String {
-                    #lower_case_name_as_str.to_string()
+                    <#name as JsonApiResource>::resource_name().to_string()
                 }
             }
 

--- a/rustiful-derive/src/params.rs
+++ b/rustiful-derive/src/params.rs
@@ -15,12 +15,12 @@ pub fn expand_json_api_fields(name: &syn::Ident,
                               attrs: &[Attribute],
                               &(ref id, ref fields): &(JsonApiField, Vec<JsonApiField>))
                               -> Tokens {
-    let lower_case_name = name.to_string().to_snake_case();
     let json_api_id_ty = &id.field.ty;
 
-    let json_name = get_json_name(&lower_case_name, attrs);
+    let lower_case_name = name.to_string().to_snake_case();
+    let pluralized_name = lower_case_name.to_plural().to_kebab_case();
     let lower_cased_ident = Ident::new(lower_case_name);
-    let pluralized_name = json_name.to_plural().to_kebab_case();
+    let json_name = get_json_name(&pluralized_name, attrs);
 
     let mut option_fields: Vec<_> = Vec::with_capacity(fields.len());
     let option_fields_len = fields.len();

--- a/rustiful-test/tests/lib.rs
+++ b/rustiful-test/tests/lib.rs
@@ -56,7 +56,7 @@ fn parse_params_fails_on_id_param() {
 #[test]
 fn parse_present_field() {
     use self::foo::field::*;
-    match <Foo as JsonApiResource>::from_str("fields[foo]=foo") {
+    match <Foo as JsonApiResource>::from_str("fields[foos]=foo") {
         Ok(result) => assert_eq!(Some(&foo), result.fieldset.fields.first()),
         Err(e) => assert!(false, format!("unexpected error!, {:?}", e)),
     }
@@ -65,7 +65,7 @@ fn parse_present_field() {
 #[test]
 fn parse_present_url_encoded_field() {
     use self::foo::field::*;
-    match <Foo as JsonApiResource>::from_str("fields%5Bfoo%5D=foo") {
+    match <Foo as JsonApiResource>::from_str("fields%5Bfoos%5D=foo") {
         Ok(result) => assert_eq!(Some(&foo), result.fieldset.fields.first()),
         Err(e) => assert!(false, format!("unexpected error!, {:?}", e)),
     }
@@ -100,7 +100,7 @@ fn parse_fields_fails_if_fields_value_is_empty() {
 
 #[test]
 fn parse_fields_fails_if_field_value_contains_field_that_does_not_exist() {
-    match <Foo as JsonApiResource>::from_str("fields[foo]=non_existent") {
+    match <Foo as JsonApiResource>::from_str("fields[foos]=non_existent") {
         Ok(_) => assert!(false, "expected error but no error happened!"),
         Err(e) => {
             assert_eq!(QueryStringParseError::InvalidValue("non_existent".to_string()),

--- a/rustiful-test/tests/post_and_patch_tests.rs
+++ b/rustiful-test/tests/post_and_patch_tests.rs
@@ -338,10 +338,10 @@ fn post_with_client_generated_id_and_fieldset_params() {
     }}"#,
                        id);
 
-    let created = do_post_with_url(&data, "http://localhost:3000/tests?fields[test]=title");
+    let created = do_post_with_url(&data, "http://localhost:3000/tests?fields[tests]=title");
     let expected =
         JsonApiData::new(Some(id),
-                         "test",
+                         "tests",
                          <Test as ToJson>::Attrs::new(Some("test".to_string()), Some(None), None));
 
     assert_eq!(created.data, expected);
@@ -462,9 +462,9 @@ fn update_with_fieldset() {
         }}"#,
                             &id);
 
-        let updated = do_patch_with_url(&id, &patch, "fields[test]=title");
+        let updated = do_patch_with_url(&id, &patch, "fields[tests]=title");
         let expected = JsonApiData::new(Some(id),
-                                        "test",
+                                        "tests",
                                         <Test as ToJson>::Attrs::new(Some("funky".to_string()),
                                                                      Some(None),
                                                                      None));

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -211,7 +211,7 @@ fn parse_json_api_index_get() {
 #[test]
 fn parse_json_api_index_get_with_fieldset() {
     let headers = Headers::new();
-    let response = request::get("http://localhost:3000/foos?fields[foo]=title",
+    let response = request::get("http://localhost:3000/foos?fields[foos]=title",
                                 headers,
                                 &app_router())
             .unwrap();
@@ -221,16 +221,8 @@ fn parse_json_api_index_get_with_fieldset() {
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
     let records: JsonApiArray<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
-    let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
-
-    let test = Foo {
-        id: "1".to_string(),
-        body: "test".to_string(),
-        title: "test".to_string(),
-        published: true,
-    };
     let data = JsonApiData::new(Some("1"),
-                                "foo",
+                                "foos",
                                 <Foo as ToJson>::Attrs::new(Some("test".to_string()), None, None));
     let expected = JsonApiArray { data: vec![data] };
 


### PR DESCRIPTION
For the sake of consistency (and because the spec says that a consistent
naming should be applied everywhere), pluralize the type name of the
data object and the fieldset parameter.