### PR TITLE
Reverse rustiful-derive dependency

### DIFF
--- a/rustiful-derive/Cargo.toml
+++ b/rustiful-derive/Cargo.toml
@@ -11,7 +11,6 @@ description = "This is the derive crate, intended to be used with the rustiful c
 proc-macro = true
 
 [dependencies]
-rustiful = { version = "0.1.0" }
 syn = "0.11"
 quote = "0.3"
 Inflector = "0.10"

--- a/rustiful-derive/src/builder.rs
+++ b/rustiful-derive/src/builder.rs
@@ -59,9 +59,11 @@ pub fn expand_json_api_builders(name: &Ident,
         mod #mod_name {
             #uuid
 
+            extern crate rustiful as _rustiful;
+
             use super::#name;
-            use rustiful::ToBuilder;
-            use rustiful::JsonApiBuilder;
+            use self::_rustiful::ToBuilder;
+            use self::_rustiful::JsonApiBuilder;
 
             #[derive(Debug, Default)]
             pub struct Builder {

--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -55,17 +55,17 @@ pub fn expand_json_api_models(name: &syn::Ident,
         mod #mod_name {
             #uuid
 
-            extern crate rustiful;
+            extern crate rustiful as _rustiful;
 
             use super::#name;
             use std::str::FromStr;
-            use rustiful::ToJson;
-            use rustiful::TryFrom;
-            use rustiful::TryInto;
-            use rustiful::ToBuilder;
-            use rustiful::JsonApiData;
-            use rustiful::JsonApiBuilder;
-            use rustiful::JsonApiResource;
+            use self::_rustiful::ToJson;
+            use self::_rustiful::TryFrom;
+            use self::_rustiful::TryInto;
+            use self::_rustiful::ToBuilder;
+            use self::_rustiful::JsonApiData;
+            use self::_rustiful::JsonApiBuilder;
+            use self::_rustiful::JsonApiResource;
 
             #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
             pub struct JsonApiAttributes {
@@ -160,7 +160,7 @@ pub fn expand_json_api_models(name: &syn::Ident,
 pub fn generate_option_field(ident: &syn::Ident, ty: &Ty, generate_serde_attribute: bool) -> Tokens {
     if util::is_option_ty(ty) && generate_serde_attribute {
         quote! {
-                #[serde(default, deserialize_with = "rustiful::json_option::some_option")]
+                #[serde(default, deserialize_with = "self::_rustiful::json_option::some_option")]
                 pub #ident: Option<#ty>
         }
     } else {

--- a/rustiful-derive/src/params.rs
+++ b/rustiful-derive/src/params.rs
@@ -1,5 +1,4 @@
 extern crate syn;
-extern crate rustiful;
 extern crate inflector;
 
 use self::inflector::Inflector;
@@ -48,13 +47,15 @@ pub fn expand_json_api_fields(name: &syn::Ident,
         pub mod #lower_cased_ident {
             #uuid
 
+            extern crate rustiful as _rustiful;
+
             use super::#name;
             use std::slice::Iter;
-            use rustiful::TryFrom;
-            use rustiful::SortOrder;
-            use rustiful::JsonApiParams;
-            use rustiful::JsonApiResource;
-            use rustiful::QueryStringParseError;
+            use self::_rustiful::TryFrom;
+            use self::_rustiful::SortOrder;
+            use self::_rustiful::JsonApiParams;
+            use self::_rustiful::JsonApiResource;
+            use self::_rustiful::QueryStringParseError;
 
             #[derive(Debug, PartialEq, Eq, Clone)]
             #[allow(non_camel_case_types)]

--- a/rustiful/Cargo.toml
+++ b/rustiful/Cargo.toml
@@ -13,6 +13,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 hyper = "0.10"
 uuid = { version = "0.5", optional = true, features = ["serde"] }
+rustiful-derive = { version = "0.1", optional = true }
 autoimpl = "0.1"
 url = "1.4"
 
@@ -30,4 +31,5 @@ dev = ["clippy", "iron", "router", "bodyparser", "persistent"]
 iron = "0.5"
 router = "0.5"
 iron-test = "0.5"
-uuid = { version = "0.4", features = ["serde", "v4"] }
+rustiful-derive = { version = "0.1", features = ["uuid"] }
+uuid = { version = "0.5", features = ["serde", "v4"] }

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -63,3 +63,11 @@ pub mod status {
 }
 
 pub mod json_option;
+
+#[cfg(feature = "rustiful-derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate rustiful_derive;
+#[cfg(feature = "rustiful-derive")]
+#[doc(hidden)]
+pub use rustiful_derive::*;


### PR DESCRIPTION
There's no good reason for rustiful-derive to depend on rustiful. On the
other hand, adding an optional dependency for rustiful-derive on
rustiful makes it easier to test things within the rustiful module.

The `extern crate rustiful as _rustiful` within the derive files enables
a user to derive `JsonApi` without having to type
`extern crate rustiful`.