### PR TITLE
Handler simplification

### DIFF
--- a/rustiful/src/iron/handlers/delete.rs
+++ b/rustiful/src/iron/handlers/delete.rs
@@ -5,8 +5,10 @@ use super::Status;
 use super::super::RequestResult;
 use FromRequest;
 use errors::FromRequestError;
+use errors::IdParseError;
+use errors::RequestError;
+use request::delete::delete;
 use iron::id;
-use request::FromDelete;
 use service::JsonDelete;
 use std::error::Error;
 use std::str::FromStr;
@@ -14,20 +16,26 @@ use try_from::TryInto;
 
 autoimpl! {
     pub trait DeleteHandler<'a, T>
-        where T: JsonDelete + FromDelete<'a, T>,
+        where T: JsonDelete,
               T::Error: 'static,
               Status: for<'b> From<&'b T::Error>,
-              <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn delete(req: &'a mut Request) -> IronResult<Response> {
-            match FromRequest::from_request(req) {
-                Ok(res) => {
-                    let result = <T as FromDelete<T>>::delete(id(req), res);
-                    RequestResult(result, Status::NoContent).try_into()
-                },
-                Err(e) => FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            }
+        fn respond(req: &'a mut Request) -> IronResult<Response> {
+            let ctx = match <T::Context as FromRequest>::from_request(req) {
+                Ok(result) => result,
+                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
+            };
+
+            let id = match <T::JsonApiIdType>::from_str(id(req)) {
+                Ok(result) => result,
+                Err(e) => {
+                    return RequestError::IdParseError::<T::Error, T::JsonApiIdType>(IdParseError(e)).into()
+                }
+            };
+
+            let result = delete::<T>(id, ctx);
+            RequestResult(result, Status::NoContent).try_into()
         }
     }
 }

--- a/rustiful/src/iron/handlers/get.rs
+++ b/rustiful/src/iron/handlers/get.rs
@@ -7,9 +7,11 @@ use self::iron::prelude::*;
 use super::super::RequestResult;
 use FromRequest;
 use errors::FromRequestError;
+use errors::IdParseError;
 use errors::QueryStringParseError;
+use errors::RequestError;
 use iron::id;
-use request::FromGet;
+use request::get::get;
 use service::JsonGet;
 use sort_order::SortOrder;
 use status::Status;
@@ -21,23 +23,28 @@ use try_from::TryInto;
 
 autoimpl! {
     pub trait GetHandler<'a, T> where
-        T: JsonGet + ToJson + FromGet<'a, T>,
+        T: JsonGet + ToJson,
         T::Error: 'static,
-        <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
         T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn get(req: &'a mut Request) -> IronResult<Response> {
-            let query = req.url.query().unwrap_or("");
-            match FromRequest::from_request(req) {
-                Ok(res) => {
-                    let result = T::get(id(req), query, res);
-                    RequestResult(result, Status::Ok).try_into()
-                },
-                Err(e) => FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            }
+        fn respond(req: &'a mut Request) -> IronResult<Response> {
+            let ctx = match <T::Context as FromRequest>::from_request(req) {
+                Ok(result) => result,
+                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
+            };
+
+            let id = match <T::JsonApiIdType>::from_str(id(req)) {
+                Ok(result) => result,
+                Err(e) => {
+                    return RequestError::IdParseError::<T::Error, T::JsonApiIdType>(IdParseError(e)).into()
+                }
+            };
+
+            let result = get::<T>(id, req.url.query().unwrap_or(""), ctx);
+            RequestResult(result, Status::Ok).try_into()
         }
     }
 }

--- a/rustiful/src/iron/handlers/index.rs
+++ b/rustiful/src/iron/handlers/index.rs
@@ -8,7 +8,7 @@ use super::super::RequestResult;
 use FromRequest;
 use errors::FromRequestError;
 use errors::QueryStringParseError;
-use request::FromIndex;
+use request::index::index;
 use service::JsonIndex;
 use sort_order::SortOrder;
 use status::Status;
@@ -20,24 +20,21 @@ use try_from::TryInto;
 
 autoimpl! {
     pub trait IndexHandler<'a, T> where
-        T: JsonIndex + ToJson + FromIndex<'a, T>,
+        T: JsonIndex + ToJson,
         T::Error: 'static,
-        <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
         T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn get(req: &'a mut Request) -> IronResult<Response> {
-            let query = req.url.query().unwrap_or("");
+        fn respond(req: &'a mut Request) -> IronResult<Response> {
+            let ctx = match <T::Context as FromRequest>::from_request(req) {
+                Ok(result) => result,
+                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
+            };
 
-            match FromRequest::from_request(req) {
-                Ok(res) => {
-                    let result = <T as FromIndex<T>>::get(query, res);
-                    RequestResult(result, Status::Ok).try_into()
-                },
-                Err(e) => FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            }
+            let result = index::<T>(req.url.query().unwrap_or(""), ctx);
+            RequestResult(result, Status::Ok).try_into()
         }
     }
 }

--- a/rustiful/src/iron/handlers/patch.rs
+++ b/rustiful/src/iron/handlers/patch.rs
@@ -8,50 +8,56 @@ use super::errors::BodyParserError;
 use super::super::RequestResult;
 use FromRequest;
 use errors::FromRequestError;
+use errors::IdParseError;
+use errors::QueryStringParseError;
 use errors::RequestError;
 use iron::id;
 use object::JsonApiObject;
-use request::FromPatch;
+use request::patch::patch;
 use serde::Deserialize;
 use service::JsonPatch;
+use sort_order::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;
-use try_from::TryInto;
 use try_from::TryFrom;
-use sort_order::SortOrder;
-use errors::QueryStringParseError;
+use try_from::TryInto;
 
 autoimpl! {
     pub trait PatchHandler<'a, T> where
-        T: JsonPatch + ToJson + FromPatch<'a, T>,
+        T: JsonPatch + ToJson,
         T::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
-        <T::Context as FromRequest>::Error: 'static,
         T::Attrs: 'static + for<'b> Deserialize<'b>,
         T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn patch(req: &'a mut Request) -> IronResult<Response> {
-            match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
-                Ok(Some(patch)) => {
-                    match FromRequest::from_request(req) {
-                        Ok(res) => {
-                            let query = req.url.query().unwrap_or("");
-                            let result = <T as FromPatch<T>>::patch(id(req), query, patch.data, res);
-                            RequestResult(result, Status::Ok).try_into()
-                        },
-                        Err(e) => FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-                    }
-                },
+        fn respond(req: &'a mut Request) -> IronResult<Response> {
+            let json = match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
+                Ok(Some(patch)) => patch,
                 Ok(None) => {
                     let err:RequestError<T::Error, T::JsonApiIdType> = RequestError::NoBody;
-                    err.into()
+                    return err.into()
                 },
-                Err(e) => BodyParserError(e).into()
-            }
+                Err(e) => return BodyParserError(e).into()
+            };
+
+            let ctx = match <T::Context as FromRequest>::from_request(req) {
+                Ok(result) => result,
+                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
+            };
+
+            let id = match <T::JsonApiIdType>::from_str(id(req)) {
+                Ok(result) => result,
+                Err(e) => {
+                    return RequestError::IdParseError::<T::Error, T::JsonApiIdType>(IdParseError(e)).into()
+                }
+            };
+
+            let result = patch::<T>(id, req.url.query().unwrap_or(""), json.data, ctx);
+            RequestResult(result, Status::Ok).try_into()
         }
     }
 }

--- a/rustiful/src/iron/handlers/post.rs
+++ b/rustiful/src/iron/handlers/post.rs
@@ -8,23 +8,23 @@ use super::errors::BodyParserError;
 use super::super::RequestResult;
 use FromRequest;
 use errors::FromRequestError;
+use errors::QueryStringParseError;
 use errors::RequestError;
 use object::JsonApiObject;
-use request::FromPost;
+use request::post::post;
 use serde::Deserialize;
 use service::JsonPost;
+use sort_order::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;
-use try_from::TryInto;
 use try_from::TryFrom;
-use sort_order::SortOrder;
-use errors::QueryStringParseError;
+use try_from::TryInto;
 
 autoimpl! {
     pub trait PostHandler<'a, T> where
-        T: JsonPost + ToJson + FromPost<'a, T>,
+        T: JsonPost + ToJson,
         T::Error: 'static,
         <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
@@ -33,24 +33,23 @@ autoimpl! {
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
         <T::JsonApiIdType as FromStr>::Err: Error
     {
-        fn post(req: &'a mut Request) -> IronResult<Response> {
-            match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
-                Ok(Some(post)) => {
-                    match FromRequest::from_request(req) {
-                        Ok(res) => {
-                            let query = req.url.query().unwrap_or("");
-                            let result = <T as FromPost<T>>::create(query, post.data, res);
-                            RequestResult(result, Status::Created).try_into()
-                        },
-                        Err(e) => FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-                    }
-                },
+        fn respond(req: &'a mut Request) -> IronResult<Response> {
+            let json = match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
+                Ok(Some(patch)) => patch,
                 Ok(None) => {
                     let err:RequestError<T::Error, T::JsonApiIdType> = RequestError::NoBody;
-                    err.into()
+                    return err.into()
                 },
-                Err(e) => BodyParserError(e).into()
-            }
+                Err(e) => return BodyParserError(e).into()
+            };
+
+            let ctx = match <T::Context as FromRequest>::from_request(req) {
+                Ok(result) => result,
+                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
+            };
+
+            let result = post::<T>(req.url.query().unwrap_or(""), json.data, ctx);
+            RequestResult(result, Status::Created).try_into()
         }
     }
 }

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -20,7 +20,6 @@ use errors::QueryStringParseError;
 use errors::RequestError;
 use iron::handlers::BodyParserError;
 use iron::router::Router;
-use params::JsonApiResource;
 use serde::Serialize;
 use serde::de::Deserialize;
 use service::*;
@@ -30,7 +29,6 @@ use status::Status;
 use std::error::Error;
 use std::fmt::Debug;
 use std::str::FromStr;
-use to_json::ToJson;
 use try_from::TryFrom;
 
 fn json_api_type() -> Mime {
@@ -115,7 +113,7 @@ impl From<BodyParserError> for IronResult<Response> {
     }
 }
 
-pub fn id<'a>(req: &'a Request) -> &'a str {
+fn id<'a>(req: &'a Request) -> &'a str {
     let router = req.extensions
         .get::<Router>()
         .expect("Expected to get a Router from the request extensions.");
@@ -125,8 +123,226 @@ pub fn id<'a>(req: &'a Request) -> &'a str {
 }
 
 
-/// This is used to construct an Iron `Chain`, and also sets up a bodyparser with a default max body
-/// length.
+/// Constructs a builder for configuring routes for resources implementing any of the `JsonGet`,
+/// `JsonPost`, `JsonIndex`, `JsonPatch` or `JsonDelete` traits.
+///
+/// In order for a resource to be routable we need to configure the routes of the resource. This
+/// is what `JsonApiRouterBuilder` does. This builder can create routes for any type implementing
+/// any of the `JsonGet`, `JsonPost`, `JsonIndex`, `JsonPatch` or `JsonDelete` traits. We also need
+/// to ensure that there are corresponding `From` implementations for all of the distinct error
+/// types that are implemented on the above resource traits for `rustiful::status::Status`.
+///
+/// By default a resource will have a pluralized, lower-cased, dasherized name of its type name (aka
+/// kebab-case). If a resource is named `MyResource`, it will have the resource name `my-resources`.
+/// This can be overridden by using the Serde `rename` attribute on the resource type.
+///
+/// # Example
+///
+/// Given a resource with a valid `JsonIndex` impl, such as the one below:
+///
+/// ```rust
+/// # extern crate iron;
+/// # extern crate rustiful;
+/// #
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # use std::default::Default;
+/// # use rustiful::JsonApiData;
+/// # use rustiful::JsonIndex;
+/// # use rustiful::IntoJson;
+/// #
+/// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+/// struct MyResource {
+///     id: String,
+///     foo: bool,
+///     bar: String
+/// }
+///
+/// # struct MyCtx {
+/// # }
+/// #
+/// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+/// #     type Error = MyError;
+/// #
+/// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+/// #         Ok(MyCtx {})
+/// #     }
+/// # }
+/// #
+/// # #[derive(Debug)]
+/// # struct MyError {
+/// # }
+/// #
+/// # impl std::error::Error for MyError {
+/// #    fn description(&self) -> &str {
+/// #        "No error here!"
+/// #    }
+/// #
+/// #    fn cause(&self) -> Option<&std::error::Error> {
+/// #        None
+/// #    }
+/// # }
+/// #
+/// # impl std::fmt::Display for MyError {
+/// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+/// #        write!(f, "No error here!")
+/// #    }
+/// # }
+/// #
+/// impl JsonIndex for MyResource {
+/// #    type Context = MyCtx;
+///     type Error = MyError;
+/// #
+/// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+/// #                 ctx: Self::Context)
+/// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+/// #          Ok(vec![MyResource::default().into_json(params)])
+/// #      }
+/// }
+/// #
+/// # fn main() {
+/// # }
+/// ```
+///
+/// We also need to ensure that we are able to convert `JsonIndex::Error` to an Iron HTTP status.
+///
+/// ```
+/// # extern crate rustiful;
+/// #
+/// # struct MyError {
+/// # }
+/// #
+/// impl<'a> From<&'a MyError> for rustiful::status::Status {
+///     fn from(error: &'a MyError) -> Self {
+///         rustiful::status::ImATeapot
+///     }
+/// }
+/// ```
+///
+/// Construct a `GET` route for this resource by calling `jsonapi_index`.
+///
+/// ```rust
+/// # extern crate iron;
+/// # extern crate rustiful;
+/// #
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # use std::default::Default;
+/// # use rustiful::JsonApiData;
+/// # use rustiful::JsonIndex;
+/// # use rustiful::IntoJson;
+/// # use rustiful::iron::JsonApiRouterBuilder;
+/// #
+/// # #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+/// # struct MyResource {
+/// #    id: String,
+/// #    foo: bool,
+/// #    bar: String
+/// # }
+/// #
+/// # struct MyCtx {
+/// # }
+/// #
+/// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+/// #     type Error = MyError;
+/// #
+/// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+/// #         Ok(MyCtx {})
+/// #     }
+/// # }
+/// #
+/// # #[derive(Debug)]
+/// # struct MyError {
+/// # }
+/// #
+/// # impl std::error::Error for MyError {
+/// #    fn description(&self) -> &str {
+/// #        "No error here!"
+/// #    }
+/// #
+/// #    fn cause(&self) -> Option<&std::error::Error> {
+/// #        None
+/// #    }
+/// # }
+/// #
+/// # impl std::fmt::Display for MyError {
+/// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+/// #        write!(f, "No error here!")
+/// #    }
+/// # }
+/// #
+/// # impl JsonIndex for MyResource {
+/// #    type Context = MyCtx;
+/// #    type Error = MyError;
+/// #
+/// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+/// #                 ctx: Self::Context)
+/// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+/// #          Ok(vec![MyResource::default().into_json(params)])
+/// #      }
+/// # }
+/// #
+/// # impl<'a> From<&'a MyError> for rustiful::status::Status {
+/// #   fn from(error: &'a MyError) -> Self {
+/// #       rustiful::status::ImATeapot
+/// #   }
+/// # }
+/// #
+/// # fn main() {
+/// let mut router = JsonApiRouterBuilder::default();
+/// router.jsonapi_index::<MyResource>();
+/// # }
+/// ```
+///
+/// This resource will then have the route `GET /my-resources`.
+///
+/// We can then build the `Router` and pass it into the Iron server constructor.
+///
+/// ```rust,no_run
+/// extern crate iron;
+/// # extern crate rustiful;
+///
+/// # use rustiful::iron::JsonApiRouterBuilder;
+/// use iron::Iron;
+///
+/// fn main() {
+/// # let router = JsonApiRouterBuilder::default();
+///     // Start the server.
+///     Iron::new(router.build()).http("localhost:3000").unwrap();
+/// }
+/// ```
+///
+/// If you want to change the resource name, we can modify the resource by using the Serde `rename`
+/// attribute.
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// #[macro_use]
+/// extern crate serde_derive;
+///
+/// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi, Serialize, Deserialize)]
+/// #[serde(rename = "crazy-resource-name")]
+/// struct MyResource {
+///     id: String,
+///     foo: bool,
+///     bar: String
+/// }
+/// #
+/// # fn main() {
+/// # }
+/// ```
+///
+/// This resource will then have the route `GET /crazy-resource-name`.
 #[allow(missing_debug_implementations)] // The underlying Router doesn't implement Debug...
 pub struct JsonApiRouterBuilder {
     router: Router,
@@ -142,7 +358,24 @@ impl Default for JsonApiRouterBuilder {
 }
 
 impl JsonApiRouterBuilder {
-    fn new(router: Router, max_body_length: usize) -> Self {
+    /// Constructs a new `JsonApiRouterBuilder`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate router;
+    /// extern crate rustiful;
+    ///
+    /// use router::Router;
+    /// use rustiful::iron::JsonApiRouterBuilder;
+    ///
+    /// fn main() {
+    ///       // Creates a new JsonApiRouterBuilder with an iron router and a 1MB maximum body
+    ///       // length.
+    ///       let builder = JsonApiRouterBuilder::new(Router::new(), 1 * 1024 * 1024);
+    /// }
+    /// ```
+    pub fn new(router: Router, max_body_length: usize) -> Self {
         JsonApiRouterBuilder {
             router: router,
             max_body_length: max_body_length,
@@ -150,108 +383,907 @@ impl JsonApiRouterBuilder {
     }
 
     /// Sets the max body length for any incoming JSON document. This is specified in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate rustiful;
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// #
+    /// # fn main() {
+    ///       let mut builder = JsonApiRouterBuilder::default();
+    ///       // Sets the maximum allowed body length to 1MB.
+    ///       builder.set_max_body_length(1 * 1024 * 1024);
+    /// # }
+    /// ```
     pub fn set_max_body_length(&mut self, max_body_length: usize) {
         self.max_body_length = max_body_length;
     }
 
     /// Setup a route for a struct that implements `JsonIndex` and `JsonApiResource`
+    ///
+    /// # Example
+    ///
+    /// Given a resource with a valid `JsonIndex` impl, such as the one below:
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use std::default::Default;
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonIndex;
+    /// # use rustiful::IntoJson;
+    /// #
+    /// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// struct MyResource {
+    ///     id: String,
+    ///     foo: bool,
+    ///     bar: String
+    /// }
+    ///
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// impl JsonIndex for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #                 ctx: Self::Context)
+    /// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #          Ok(vec![MyResource::default().into_json(params)])
+    /// #      }
+    /// }
+    /// #
+    /// # fn main() {
+    /// # }
+    /// ```
+    ///
+    /// Construct a `GET` route for this resource by calling `jsonapi_index`.
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use std::default::Default;
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonIndex;
+    /// # use rustiful::IntoJson;
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// #
+    /// # #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// # struct MyResource {
+    /// #    id: String,
+    /// #    foo: bool,
+    /// #    bar: String
+    /// # }
+    /// #
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// # impl JsonIndex for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #                 ctx: Self::Context)
+    /// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #          Ok(vec![MyResource::default().into_json(params)])
+    /// #      }
+    /// # }
+    /// #
+    /// # impl<'a> From<&'a MyError> for rustiful::status::Status {
+    /// #   fn from(error: &'a MyError) -> Self {
+    /// #       rustiful::status::ImATeapot
+    /// #   }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// let mut router = JsonApiRouterBuilder::default();
+    /// router.jsonapi_index::<MyResource>();
+    /// # }
+    /// ```
+    ///
+    /// This resource will then have the route `GET /my-resources`.
     pub fn jsonapi_index<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonIndex + JsonApiResource + ToJson + for<'b> IndexHandler<'b, T>,
-              T::Error: Send + 'static,
-              T::JsonApiIdType: FromStr,
+              T: JsonIndex + for<'b> IndexHandler<'b, T>,
+              T::Error: 'static,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
                                               Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static,
-              <<T as JsonIndex>::Context as FromRequest>::Error: 'static
+              <T::JsonApiIdType as FromStr>::Err: Error + 'static
     {
 
         self.router
             .get(format!("/{}", T::resource_name()),
-                 move |r: &mut Request| T::get(r),
+                 move |r: &mut Request| T::respond(r),
                  format!("index_{}", T::resource_name()));
     }
 
     /// Setup a route for a struct that implements `JsonGet` and `JsonApiResource`.
+    ///
+    /// # Example
+    ///
+    /// Given a resource with a valid `JsonGet` impl, such as the one below:
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use std::default::Default;
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonGet;
+    /// # use rustiful::IntoJson;
+    /// #
+    /// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// struct MyResource {
+    ///     id: String,
+    ///     foo: bool,
+    ///     bar: String
+    /// }
+    ///
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// impl JsonGet for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #     fn find(id: Self::JsonApiIdType,
+    /// #             params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #             ctx: Self::Context)
+    /// #            -> Result<Option<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #          Ok(Some(MyResource::default().into_json(params)))
+    /// #      }
+    /// }
+    /// #
+    /// # fn main() {
+    /// # }
+    /// ```
+    ///
+    /// Construct a `GET` route for this resource by calling `jsonapi_get`.
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use std::default::Default;
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonGet;
+    /// # use rustiful::IntoJson;
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// #
+    /// # #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// # struct MyResource {
+    /// #    id: String,
+    /// #    foo: bool,
+    /// #    bar: String
+    /// # }
+    /// #
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// # impl JsonGet for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #     fn find(id: Self::JsonApiIdType,
+    /// #             params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #             ctx: Self::Context)
+    /// #            -> Result<Option<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #          Ok(Some(MyResource::default().into_json(params)))
+    /// #      }
+    /// # }
+    /// #
+    /// # impl<'a> From<&'a MyError> for rustiful::status::Status {
+    /// #   fn from(error: &'a MyError) -> Self {
+    /// #       rustiful::status::ImATeapot
+    /// #   }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// let mut router = JsonApiRouterBuilder::default();
+    /// router.jsonapi_get::<MyResource>();
+    /// # }
+    /// ```
+    ///
+    /// This resource will then have the route `GET /my-resources/{id}`.
     pub fn jsonapi_get<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonGet + JsonApiResource + ToJson + for<'b> GetHandler<'b, T>,
-              T::Error: Send + 'static,
-              T::JsonApiIdType: FromStr,
+              T: JsonGet + for<'b> GetHandler<'b, T>,
+              T::Error: 'static,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
                                               Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static,
-              <<T as JsonGet>::Context as FromRequest>::Error: 'static
+              <T::JsonApiIdType as FromStr>::Err: Error + 'static
     {
 
         self.router
             .get(format!("/{}/:id", T::resource_name()),
-                 move |r: &mut Request| T::get(r),
+                 move |r: &mut Request| T::respond(r),
                  format!("get_{}", T::resource_name()));
     }
 
     /// Setup a route for a struct that implements `JsonDelete` and `JsonApiResource`.
+    ///
+    /// # Example
+    ///
+    /// Given a resource with a valid `JsonDelete` impl, such as the one below:
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonDelete;
+    /// # use rustiful::IntoJson;
+    /// #
+    /// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// struct MyResource {
+    ///     id: String,
+    ///     foo: bool,
+    ///     bar: String
+    /// }
+    ///
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// impl JsonDelete for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #    fn delete(id: Self::JsonApiIdType, ctx: Self::Context) -> Result<(), Self::Error> {
+    /// #         Ok(())
+    /// #    }
+    /// }
+    /// #
+    /// # fn main() {
+    /// # }
+    /// ```
+    ///
+    /// Construct a `DELETE` route for this resource by calling `jsonapi_delete`.
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonDelete;
+    /// # use rustiful::IntoJson;
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// #
+    /// # #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// # struct MyResource {
+    /// #    id: String,
+    /// #    foo: bool,
+    /// #    bar: String
+    /// # }
+    /// #
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// # impl JsonDelete for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #    fn delete(id: Self::JsonApiIdType, ctx: Self::Context) -> Result<(), Self::Error> {
+    /// #         Ok(())
+    /// #    }
+    /// # }
+    /// #
+    /// # impl<'a> From<&'a MyError> for rustiful::status::Status {
+    /// #   fn from(error: &'a MyError) -> Self {
+    /// #       rustiful::status::ImATeapot
+    /// #   }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// let mut router = JsonApiRouterBuilder::default();
+    /// router.jsonapi_delete::<MyResource>();
+    /// # }
+    /// ```
+    ///
+    /// This resource will then have the route `DELETE /my-resources/{id}`.
     pub fn jsonapi_delete<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonDelete + JsonApiResource + ToJson + for<'b> DeleteHandler<'b, T>,
-              T::Error: Send + 'static,
-              T::JsonApiIdType: FromStr,
-              <T::Context as FromRequest>::Error: 'static,
+              T: JsonDelete + for<'b> DeleteHandler<'b, T>,
+              T::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
 
         self.router
             .delete(format!("/{}/:id", T::resource_name()),
-                    move |r: &mut Request| <T as DeleteHandler<T>>::delete(r),
+                    move |r: &mut Request| T::respond(r),
                     format!("delete_{}", T::resource_name()));
     }
 
 
-    /// Setup a route for a struct that implements `JsonPost` and `JsonApiResource`.
+    /// Setup a `POST` route for a type that implements `JsonPost` and `JsonApiResource`.
+    ///
+    /// # Example
+    ///
+    /// Given a resource with a valid `JsonPost` impl, such as the one below:
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonPost;
+    /// # use rustiful::IntoJson;
+    /// #
+    /// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// struct MyResource {
+    ///     id: String,
+    ///     foo: bool,
+    ///     bar: String
+    /// }
+    ///
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// impl JsonPost for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #    fn create(json: rustiful::JsonApiData<Self::Attrs>,
+    /// #         params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #          ctx: Self::Context)
+    /// #          -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #         Ok(MyResource::default().into_json(params))
+    /// #    }
+    /// }
+    /// #
+    /// # fn main() {
+    /// # }
+    /// ```
+    ///
+    /// Construct a `POST` route for this resource by calling `jsonapi_post`.
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonPost;
+    /// # use rustiful::IntoJson;
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// #
+    /// # #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// # struct MyResource {
+    /// #    id: String,
+    /// #    foo: bool,
+    /// #    bar: String
+    /// # }
+    /// #
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// # impl JsonPost for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #    fn create(json: rustiful::JsonApiData<Self::Attrs>,
+    /// #         params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #          ctx: Self::Context)
+    /// #          -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #         let resource = MyResource {
+    /// #             id: "some_id".to_string(),
+    /// #             foo: true,
+    /// #             bar: "abc".to_string()
+    /// #         };
+    /// #
+    /// #         Ok(resource.into_json(params))
+    /// #    }
+    /// # }
+    /// #
+    /// # impl<'a> From<&'a MyError> for rustiful::status::Status {
+    /// #   fn from(error: &'a MyError) -> Self {
+    /// #       rustiful::status::ImATeapot
+    /// #   }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// let mut router = JsonApiRouterBuilder::default();
+    /// router.jsonapi_post::<MyResource>();
+    /// # }
+    /// ```
+    /// This resource will then have the route `POST /my-resources`.
     pub fn jsonapi_post<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonPost + JsonApiResource + ToJson + for<'b> PostHandler<'b, T>,
-              T::Error: Send + 'static,
-              T::JsonApiIdType: FromStr,
+              T: JsonPost + for<'b> PostHandler<'b, T>,
+              T::Error: 'static,
               T::Attrs: 'static + for<'b> Deserialize<'b>,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
-                  Error = QueryStringParseError>,
+                                              Error = QueryStringParseError>,
               <T::Context as FromRequest>::Error: 'static,
               <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
     {
 
         self.router
             .post(format!("/{}", T::resource_name()),
-                  move |r: &mut Request| T::post(r),
+                  move |r: &mut Request| T::respond(r),
                   format!("create_{}", T::resource_name()));
     }
 
-    /// Setup a route for a struct that implements `JsonPatch` and `JsonApiResource`.
+    /// Configures a route for a type that implements `JsonPatch` and `JsonApiResource`.
+    ///
+    /// # Example
+    ///
+    /// Given a resource with a valid `JsonPatch` impl, such as the one below:
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonPatch;
+    /// # use rustiful::IntoJson;
+    /// #
+    /// #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// struct MyResource {
+    ///     id: String,
+    ///     foo: bool,
+    ///     bar: String
+    /// }
+    ///
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// impl JsonPatch for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #    fn update(id: Self::JsonApiIdType,
+    /// #              json: rustiful::JsonApiData<Self::Attrs>,
+    /// #              params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #              ctx: Self::Context)
+    /// #              -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #         let resource = MyResource {
+    /// #             id: "some_id".to_string(),
+    /// #             foo: true,
+    /// #             bar: "abc".to_string()
+    /// #         };
+    /// #
+    /// #         Ok(resource.into_json(params))
+    /// #    }
+    /// }
+    /// #
+    /// # fn main() {
+    /// # }
+    /// ```
+    ///
+    /// Construct a `PATCH` route for this resource by calling `jsonapi_patch`.
+    ///
+    /// ```rust
+    /// # extern crate iron;
+    /// # extern crate rustiful;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate rustiful_derive;
+    /// #
+    /// # #[macro_use]
+    /// # extern crate serde_derive;
+    /// #
+    /// # use rustiful::JsonApiData;
+    /// # use rustiful::JsonPatch;
+    /// # use rustiful::IntoJson;
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// #
+    /// # #[derive(Debug, Default, PartialEq, Eq, Clone, JsonApi)]
+    /// # struct MyResource {
+    /// #    id: String,
+    /// #    foo: bool,
+    /// #    bar: String
+    /// # }
+    /// #
+    /// # struct MyCtx {
+    /// # }
+    /// #
+    /// # impl rustiful::iron::from_request::FromRequest for MyCtx {
+    /// #     type Error = MyError;
+    /// #
+    /// #     fn from_request(req: &iron::request::Request) -> Result<Self, Self::Error> {
+    /// #         Ok(MyCtx {})
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyError {
+    /// # }
+    /// #
+    /// # impl std::error::Error for MyError {
+    /// #    fn description(&self) -> &str {
+    /// #        "No error here!"
+    /// #    }
+    /// #
+    /// #    fn cause(&self) -> Option<&std::error::Error> {
+    /// #        None
+    /// #    }
+    /// # }
+    /// #
+    /// # impl std::fmt::Display for MyError {
+    /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// #        write!(f, "No error here!")
+    /// #    }
+    /// # }
+    /// #
+    /// # impl JsonPatch for MyResource {
+    /// #    type Context = MyCtx;
+    /// #    type Error = MyError;
+    /// #
+    /// #    fn update(id: Self::JsonApiIdType,
+    /// #              json: rustiful::JsonApiData<Self::Attrs>,
+    /// #              params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
+    /// #              ctx: Self::Context)
+    /// #              -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #         let resource = MyResource {
+    /// #             id: "some_id".to_string(),
+    /// #             foo: true,
+    /// #             bar: "abc".to_string()
+    /// #         };
+    /// #
+    /// #         Ok(resource.into_json(params))
+    /// #    }
+    /// # }
+    /// #
+    /// # impl<'a> From<&'a MyError> for rustiful::status::Status {
+    /// #   fn from(error: &'a MyError) -> Self {
+    /// #       rustiful::status::ImATeapot
+    /// #   }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// let mut router = JsonApiRouterBuilder::default();
+    /// router.jsonapi_patch::<MyResource>();
+    /// # }
+    /// ```
+    ///
+    /// This resource will then have the route `PATCH /my-resources/{id}`.
     pub fn jsonapi_patch<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonPatch + JsonApiResource + ToJson + for<'b> PatchHandler<'b, T>,
-              T::Error: Send + 'static,
-              T::JsonApiIdType: FromStr,
+              T: JsonPatch + for<'b> PatchHandler<'b, T>,
+              T::Error: 'static,
               T::Attrs: 'static + for<'b> Deserialize<'b>,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
-                  Error = QueryStringParseError>,
-              <T::Context as FromRequest>::Error: 'static,
-              <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
+                                              Error = QueryStringParseError>,
+              <T::JsonApiIdType as FromStr>::Err: Error + 'static
     {
 
         self.router
             .patch(format!("/{}/:id", T::resource_name()),
-                   move |r: &mut Request| T::patch(r),
+                   move |r: &mut Request| T::respond(r),
                    format!("update_{}", T::resource_name()));
     }
 
     /// Constructs an iron `Chain` with the routes that were previously specified in `jsonapi_get`,
     /// `jsonapi_post` et cetera. This also sets up the body parser, which is a prerequisite for
-    /// being able to parse JSON documents when POSTing or PATCHing a document.
+    /// being able to parse JSON documents when doing a `POST` or `PATCH`. The result of this method
+    /// can then be used in the Iron server constructor.
+    ///
+    /// ```rust,no_run
+    /// extern crate iron;
+    /// # extern crate rustiful;
+    ///
+    /// # use rustiful::iron::JsonApiRouterBuilder;
+    /// # use iron::Iron;
+    ///
+    /// # fn main() {
+    /// let router = JsonApiRouterBuilder::default();
+    /// // Start the server.
+    /// Iron::new(router.build()).http("localhost:3000").unwrap();
+    /// # }
+    /// ```
     pub fn build(self) -> Chain {
         let mut chain = iron::Chain::new(self.router);
         chain.link_before(Read::<bodyparser::MaxBodyLength>::one(self.max_body_length));

--- a/rustiful/src/request/delete.rs
+++ b/rustiful/src/request/delete.rs
@@ -1,28 +1,21 @@
 use super::Status;
-use errors::IdParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use service::JsonDelete;
 use std::error::Error;
 use std::str::FromStr;
 
-autoimpl! {
-    pub trait FromDelete<'a, T>
-        where T: JsonDelete,
-              Status: for<'b> From<&'b T::Error>,
-              <T::JsonApiIdType as FromStr>::Err: Error
-    {
-        fn delete(id: &'a str, ctx: T::Context)
-         -> Result<(), RequestError<T::Error, T::JsonApiIdType>> {
-            match <T::JsonApiIdType>::from_str(id) {
-                Ok(typed_id) => {
-                    match T::delete(typed_id, ctx) {
-                        Ok(_) => { Ok(()) },
-                        Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
-                    }
-                },
-                Err(e) => Err(RequestError::IdParseError(IdParseError(e)))
-            }
-        }
+/// This is a utility function that calls `T::delete()` and returns `()` if successful.
+///
+pub fn delete<'a, T>(id: T::JsonApiIdType, ctx: T::Context)
+    -> Result<(), RequestError<T::Error, T::JsonApiIdType>>
+    where
+        T: JsonDelete,
+        Status: for<'b> From<&'b T::Error>,
+        <T::JsonApiIdType as FromStr>::Err: Error {
+
+    match T::delete(id, ctx) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
     }
 }

--- a/rustiful/src/request/get.rs
+++ b/rustiful/src/request/get.rs
@@ -1,5 +1,4 @@
 use super::Status;
-use errors::IdParseError;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
@@ -11,35 +10,22 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 
-autoimpl! {
-    pub trait FromGet<'a, T> where
-        T: ToJson + JsonGet,
-        Status: for<'b> From<&'b T::Error>,
-        T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-        T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        <T::JsonApiIdType as FromStr>::Err: Error
-    {
-        fn get(id: &'a str, query: &'a str, ctx: T::Context)
-        -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
-            match T::from_str(query) {
-                Ok(params) => {
-                    match <T::JsonApiIdType>::from_str(id) {
-                        Ok(typed_id) => {
-                            match T::find(typed_id, &params, ctx) {
-                                Ok(result) => {
-                                    let data = result.ok_or(RequestError::NotFound)?;
-                                    Ok(JsonApiObject::<_> { data: data })
-                                },
-                                Err(e) => {
-                                    Err(RequestError::RepositoryError(RepositoryError::new(e)))
-                                }
-                            }
-                        },
-                        Err(e) => Err(RequestError::IdParseError(IdParseError(e)))
-                    }
-                },
-                Err(e) => Err(RequestError::QueryStringParseError(e))
-            }
-        }
-    }
+/// This is a utility function that calls `T::find()` and returns `JsonApiObject<T::Attrs>` if
+/// successful.
+///
+pub fn get<'a, T>(id: T::JsonApiIdType,
+                  query: &'a str,
+                  ctx: T::Context)
+                  -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+    where T: ToJson + JsonGet,
+          <T::JsonApiIdType as FromStr>::Err: Error,
+          Status: for<'b> From<&'b T::Error>,
+          T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+          T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>
+{
+    let params = T::from_str(query).map_err(|e| RequestError::QueryStringParseError(e))?;
+    let result = T::find(id, &params, ctx)
+        .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
+    let data = result.ok_or(RequestError::NotFound)?;
+    Ok(JsonApiObject::<_> { data: data })
 }

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -10,25 +10,21 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 
-autoimpl! {
-    pub trait FromIndex<'a, T> where
-        T: ToJson + JsonIndex,
-        Status: for<'b> From<&'b T::Error>,
-        T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-        T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        <T::JsonApiIdType as FromStr>::Err: Error
-    {
-        fn get(query: &'a str, ctx: T::Context)
-        -> Result<JsonApiArray<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
-            match T::from_str(query) {
-                Ok(params) => {
-                    match T::find_all(&params, ctx) {
-                        Ok(result) => Ok(JsonApiArray { data: result }),
-                        Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
-                    }
-                },
-                Err(e) => Err(RequestError::QueryStringParseError(e))
-            }
-        }
-    }
+/// This is a utility function that calls `T::find_all()` and returns `JsonApiObject<T::Attrs>` if
+/// successful.
+///
+pub fn index<'a, T>(query: &'a str,
+                    ctx: T::Context)
+                    -> Result<JsonApiArray<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+    where T: ToJson + JsonIndex,
+          <T::JsonApiIdType as FromStr>::Err: Error,
+          Status: for<'b> From<&'b T::Error>,
+          T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+          T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>
+{
+    let params = T::from_str(query)
+        .map_err(|e| RequestError::QueryStringParseError(e))?;
+    let result = T::find_all(&params, ctx)
+        .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
+    Ok(JsonApiArray::<_> { data: result })
 }

--- a/rustiful/src/request/mod.rs
+++ b/rustiful/src/request/mod.rs
@@ -4,10 +4,10 @@ pub mod index;
 pub mod patch;
 pub mod delete;
 
-pub use self::delete::*;
-
 pub use self::get::*;
 pub use self::index::*;
 pub use self::patch::*;
 pub use self::post::*;
+pub use self::delete::*;
+
 use super::status::Status;

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -1,40 +1,32 @@
 use super::Status;
 use data::JsonApiData;
-use errors::IdParseError;
+use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
 use service::JsonPatch;
+use sort_order::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
-use sort_order::SortOrder;
 use try_from::TryFrom;
-use errors::QueryStringParseError;
 
-autoimpl! {
-    pub trait FromPatch<'a, T>
-        where T: JsonPatch,
-              Status: for<'b> From<&'b T::Error>,
-              T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Error
-    {
-        fn patch(id: &'a str, query: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context)
-        -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
-            match <T::JsonApiIdType>::from_str(id) {
-                Ok(typed_id) => {
-                    match T::from_str(query) {
-                        Ok(params) => {
-                            match <T as JsonPatch>::update(typed_id, json, &params, ctx) {
-                                Ok(result) => Ok(JsonApiObject::<_> { data: result }),
-                                Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
-                            }
-                        },
-                        Err(e) => Err(RequestError::QueryStringParseError(e))
-                    }
-                },
-                Err(e) => Err(RequestError::IdParseError(IdParseError(e)))
-            }
-        }
-    }
+/// This is a utility function that calls `T::update()` and returns `JsonApiObject<T::Attrs>` if
+/// successful.
+///
+pub fn patch<'a, T>(id: T::JsonApiIdType,
+                    query: &'a str,
+                    json: JsonApiData<T::Attrs>,
+                    ctx: T::Context)
+                    -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+    where T: JsonPatch,
+          Status: for<'b> From<&'b T::Error>,
+          T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+          T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
+          <T::JsonApiIdType as FromStr>::Err: Error
+{
+    let params = T::from_str(query)
+        .map_err(|e| RequestError::QueryStringParseError(e))?;
+    let result = T::update(id, json, &params, ctx)
+        .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
+    Ok(JsonApiObject::<_> { data: result })
 }

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -1,34 +1,31 @@
 use super::Status;
 use data::JsonApiData;
+use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
 use service::JsonPost;
+use sort_order::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use try_from::TryFrom;
-use sort_order::SortOrder;
-use errors::QueryStringParseError;
 
-autoimpl! {
-    pub trait FromPost<'a, T>
-        where T: JsonPost,
-              Status: for<'b> From<&'b T::Error>,
-              T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-              T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Error
-    {
-        fn create(query: &'a str, json: JsonApiData<T::Attrs>, ctx: T::Context) ->
-        Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>> {
-            match T::from_str(query) {
-                Ok(params) => {
-                    match <T as JsonPost>::create(json, &params, ctx) {
-                        Ok(result) => Ok(JsonApiObject::<_> { data: result }),
-                        Err(e) => Err(RequestError::RepositoryError(RepositoryError::new(e)))
-                    }
-                },
-                Err(e) => Err(RequestError::QueryStringParseError(e))
-            }
-        }
-    }
+/// This is a utility function that calls `T::create()` and returns `JsonApiObject<T::Attrs>` if
+/// successful.
+///
+pub fn post<'a, T>(query: &'a str,
+                   json: JsonApiData<T::Attrs>,
+                   ctx: T::Context)
+                   -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+    where T: JsonPost,
+          Status: for<'b> From<&'b T::Error>,
+          T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
+          T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
+          <T::JsonApiIdType as FromStr>::Err: Error
+{
+    let params = T::from_str(query)
+        .map_err(|e| RequestError::QueryStringParseError(e))?;
+    let result = T::create(json, &params, ctx)
+        .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
+    Ok(JsonApiObject::<_> { data: result })
 }


### PR DESCRIPTION
* Remove the `From{Method}` traits and default impls, since this
complicates things needlessly. The things that can be reused by handler
implementations are now instead free (generic) functions. The handler
methods are all renamed to `respond` for the sake of consistency since
they are all differentiated by their types anyway, and they all take an
Iron request as an argument.
* In `mod.rs`, change the handler methods to respond, and also try to adhere to the Boy
Scout rule, which in this case is to add some documentation for the
route building methods.