### PR TITLE
Param refactor

### DIFF
--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -21,6 +21,7 @@ use rustiful::iron::JsonApiRouterBuilder;
 use rustiful::status::Status;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
 struct Foo {
@@ -194,7 +195,7 @@ fn parse_json_api_index_get() {
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
     let records: JsonApiArray<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
-    let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
+    let params = <Foo as JsonApiResource>::Params::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
         id: "1".to_string(),
@@ -237,7 +238,7 @@ fn parse_json_api_single_get() {
                                 &app_router());
     let result = response::extract_body_to_string(response.unwrap());
     let record: JsonApiObject<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
-    let params = <Foo as JsonApiResource>::from_str("").expect("failed to unwrap params");
+    let params = <Foo as JsonApiResource>::Params::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
         id: "1".to_string(),

--- a/rustiful-test/tests/service_tests.rs
+++ b/rustiful-test/tests/service_tests.rs
@@ -35,6 +35,7 @@ use std::env;
 use std::error::Error;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::str::FromStr;
 use uuid::Uuid;
 
 infer_schema!("dotenv:DATABASE_URL");
@@ -248,7 +249,7 @@ fn test_crud() {
                  &Default::default(),
                  DB(DB_POOL.get().expect("cannot get connection")))
             .unwrap();
-    let params = <Test as JsonApiResource>::from_str("").unwrap();
+    let params = <Test as JsonApiResource>::Params::from_str("").unwrap();
     let model_as_json: JsonApiData<_> = model.into_json(&Default::default());
     assert_eq!(model_as_json,
                Test::find(id.clone(),

--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -1,5 +1,5 @@
 use params::JsonApiParams;
-use params::JsonApiResource;
+use resource::JsonApiResource;
 use to_json::ToJson;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rustiful/src/iron/handlers/get.rs
+++ b/rustiful/src/iron/handlers/get.rs
@@ -13,7 +13,7 @@ use errors::RequestError;
 use iron::id;
 use request::get::get;
 use service::JsonGet;
-use sort_order::SortOrder;
+use params::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::str::FromStr;

--- a/rustiful/src/iron/handlers/index.rs
+++ b/rustiful/src/iron/handlers/index.rs
@@ -10,7 +10,7 @@ use errors::FromRequestError;
 use errors::QueryStringParseError;
 use request::index::index;
 use service::JsonIndex;
-use sort_order::SortOrder;
+use params::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::str::FromStr;

--- a/rustiful/src/iron/handlers/patch.rs
+++ b/rustiful/src/iron/handlers/patch.rs
@@ -16,7 +16,7 @@ use object::JsonApiObject;
 use request::patch::patch;
 use serde::Deserialize;
 use service::JsonPatch;
-use sort_order::SortOrder;
+use params::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::str::FromStr;

--- a/rustiful/src/iron/handlers/post.rs
+++ b/rustiful/src/iron/handlers/post.rs
@@ -14,7 +14,7 @@ use object::JsonApiObject;
 use request::post::post;
 use serde::Deserialize;
 use service::JsonPost;
-use sort_order::SortOrder;
+use params::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::str::FromStr;

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 use serde::de::Deserialize;
 use service::*;
 use service::JsonPatch;
-use sort_order::SortOrder;
+use params::SortOrder;
 use status::Status;
 use std::error::Error;
 use std::fmt::Debug;

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -39,6 +39,9 @@ pub use error::*;
 mod builder;
 pub use builder::*;
 
+mod resource;
+pub use resource::*;
+
 mod request;
 
 #[cfg(feature = "iron")]

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -12,9 +12,6 @@ pub use to_json::*;
 mod service;
 pub use service::*;
 
-mod sort_order;
-pub use sort_order::*;
-
 mod data;
 pub use data::*;
 

--- a/rustiful/src/request/get.rs
+++ b/rustiful/src/request/get.rs
@@ -23,7 +23,7 @@ pub fn get<'a, T>(id: T::JsonApiIdType,
           T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
           T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>
 {
-    let params = T::from_str(query).map_err(|e| RequestError::QueryStringParseError(e))?;
+    let params = T::Params::from_str(query).map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::find(id, &params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
     let data = result.ok_or(RequestError::NotFound)?;

--- a/rustiful/src/request/get.rs
+++ b/rustiful/src/request/get.rs
@@ -4,7 +4,7 @@ use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
 use service::JsonGet;
-use sort_order::SortOrder;
+use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -4,7 +4,7 @@ use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use service::JsonIndex;
-use sort_order::SortOrder;
+use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -22,7 +22,7 @@ pub fn index<'a, T>(query: &'a str,
           T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
           T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>
 {
-    let params = T::from_str(query)
+    let params = T::Params::from_str(query)
         .map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::find_all(&params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -5,7 +5,7 @@ use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
 use service::JsonPatch;
-use sort_order::SortOrder;
+use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use try_from::TryFrom;

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -24,7 +24,7 @@ pub fn patch<'a, T>(id: T::JsonApiIdType,
           T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
           <T::JsonApiIdType as FromStr>::Err: Error
 {
-    let params = T::from_str(query)
+    let params = T::Params::from_str(query)
         .map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::update(id, json, &params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -23,7 +23,7 @@ pub fn post<'a, T>(query: &'a str,
           T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
           <T::JsonApiIdType as FromStr>::Err: Error
 {
-    let params = T::from_str(query)
+    let params = T::Params::from_str(query)
         .map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::create(json, &params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -5,7 +5,7 @@ use errors::RepositoryError;
 use errors::RequestError;
 use object::JsonApiObject;
 use service::JsonPost;
-use sort_order::SortOrder;
+use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use try_from::TryFrom;

--- a/rustiful/src/resource.rs
+++ b/rustiful/src/resource.rs
@@ -1,0 +1,21 @@
+use std::fmt::Debug;
+use std::str::FromStr;
+use errors::QueryStringParseError;
+
+/// A trait that defines how to convert to/from a JSONAPI representation of the implementing type.
+///
+/// This trait is automatically implemented for any type that derives the `JsonApi` attribute.
+pub trait JsonApiResource: Sized {
+    /// An alias for `JsonApiParams<Self::SortField, Self::FilterField>`
+    type Params: FromStr<Err = QueryStringParseError>;
+    /// This type is typically generated in rustiful-derive.
+    type SortField;
+    /// This type is typically generated in rustiful-derive.
+    type FilterField;
+    /// The type of a field named `id` or the type of a field that has the `#[JsonApiId]` attribute
+    /// on the type deriving `JsonApi`.
+    type JsonApiIdType: FromStr + Debug;
+    /// This is typically the pluralized, lower-cased and dasherized name of the type deriving
+    /// `JsonApi`.
+    fn resource_name() -> &'static str;
+}

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -2,66 +2,60 @@ extern crate serde;
 
 use FromRequest;
 use data::JsonApiData;
-use params::JsonApiParams;
-use params::JsonApiResource;
+use resource::JsonApiResource;
 use status::Status;
 use std;
 use to_json::ToJson;
 
-pub trait JsonGet
-    where Self: JsonApiResource + ToJson
+pub trait JsonGet where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
     fn find(id: Self::JsonApiIdType,
-            params: &JsonApiParams<Self::FilterField, Self::SortField>,
+            params: &Self::Params,
             ctx: Self::Context)
             -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
-pub trait JsonPost
-    where Self: JsonApiResource + ToJson
+pub trait JsonPost where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
     fn create(json: JsonApiData<Self::Attrs>,
-              params: &JsonApiParams<Self::FilterField, Self::SortField>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
-pub trait JsonPatch
-    where Self: JsonApiResource + ToJson
+pub trait JsonPatch where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
     fn update(id: Self::JsonApiIdType,
               json: JsonApiData<Self::Attrs>,
-              params: &JsonApiParams<Self::FilterField, Self::SortField>,
+              params: &Self::Params,
               ctx: Self::Context)
               -> Result<JsonApiData<Self::Attrs>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
-pub trait JsonIndex
-    where Self: JsonApiResource + ToJson
+pub trait JsonIndex where Self: JsonApiResource + ToJson
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
-    fn find_all(params: &JsonApiParams<Self::FilterField, Self::SortField>,
+    fn find_all(params: &Self::Params,
                 ctx: Self::Context)
                 -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
-pub trait JsonDelete
-    where Self: JsonApiResource
+pub trait JsonDelete where Self: JsonApiResource
 {
     type Error: std::error::Error + Send;
     type Context: FromRequest;

--- a/rustiful/src/sort_order.rs
+++ b/rustiful/src/sort_order.rs
@@ -1,6 +1,0 @@
-
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum SortOrder {
-    Asc,
-    Desc,
-}


### PR DESCRIPTION
* Move `SortOrder` into params module, since it is used for parsing
parameters.
* Add `From<&str>` impl for `SortOrder`
* The `JsonApiResource` trait has nothing to do with parameters, apart
from having a `Params` associated type defined on it, so move that to a separate module
* It makes more sense to define the `from_str` method on `JsonApiResource`
as a `FromStr` impl on `JsonApiParams`, since the query string is used
to construct an instance of `JsonApiParams`. 