### PR TITLE
Unify JSONAPI container types

### DIFF
--- a/examples/src/todo.rs
+++ b/examples/src/todo.rs
@@ -40,7 +40,7 @@ impl JsonGet for Todo {
     fn find(id: Self::JsonApiIdType,
             params: &Self::Params,
             ctx: Self::Context)
-            -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error> {
+            -> Result<Option<JsonApiData<Self>>, Self::Error> {
         table
             .find(id)
             .first::<Todo>(ctx.conn())
@@ -57,7 +57,7 @@ impl JsonIndex for Todo {
     /// Gets all records from the database
     fn find_all(params: &Self::Params,
                 ctx: Self::Context)
-                -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error> {
+                -> Result<Vec<JsonApiData<Self>>, Self::Error> {
 
         let mut query = table.into_boxed();
 
@@ -126,10 +126,10 @@ impl JsonPatch for Todo {
     /// the record along with the JSON patch to a new instance that has the updated columns, before
     /// saving it in the database.
     fn update(id: Self::JsonApiIdType,
-              json: JsonApiData<Self::Attrs>,
+              json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+              -> Result<JsonApiData<Self>, Self::Error> {
         let record = table
             .find(&id)
             .first(ctx.conn())
@@ -166,10 +166,10 @@ impl JsonPost for Todo {
     /// must create a record with the given id. If the id is not specified (i.e the record will get
     /// an auto-generated id), then make sure that you return a record with the generated id. This
     /// is handled with the `get_result` method below.
-    fn create(record: JsonApiData<Self::Attrs>,
+    fn create(record: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+              -> Result<JsonApiData<Self>, Self::Error> {
         let todo: Todo = record.try_into().map_err(|e| MyErr::UpdateError(e))?;
         let result: NewTodo = todo.into();
         diesel::insert(&result)

--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -80,10 +80,10 @@ pub fn expand_json_api_models(name: &syn::Ident,
                 }
             }
 
-            impl TryFrom<JsonApiData<JsonApiAttributes>> for #name {
+            impl TryFrom<JsonApiData<#name>> for #name {
                 type Error = String;
 
-                fn try_from(json: JsonApiData<JsonApiAttributes>) -> Result<Self, Self::Error> {
+                fn try_from(json: JsonApiData<#name>) -> Result<Self, Self::Error> {
                     let id = json.id.clone().map(|id| {
                         match #json_api_id_ty::from_str(&id) {
                             Ok(result) => Ok(result),
@@ -104,10 +104,10 @@ pub fn expand_json_api_models(name: &syn::Ident,
                 }
             }
 
-            impl TryFrom<(#name, JsonApiData<JsonApiAttributes>)> for #name {
+            impl TryFrom<(#name, JsonApiData<#name>)> for #name {
                 type Error = String;
 
-                fn try_from((model, updated_attrs): (#name, JsonApiData<JsonApiAttributes>))
+                fn try_from((model, updated_attrs): (#name, JsonApiData<#name>))
                 -> Result<Self, Self::Error> {
                     let mut builder = <#name as ToBuilder>::Builder::new(model);
                     #(#jsonapi_builder_setter)*

--- a/rustiful-test/tests/lib.rs
+++ b/rustiful-test/tests/lib.rs
@@ -11,7 +11,6 @@ use rustiful::JsonApiData;
 use rustiful::JsonApiResource;
 use rustiful::QueryStringParseError;
 use rustiful::SortOrder::*;
-use rustiful::ToJson;
 use std::str::FromStr;
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonApi)]
@@ -231,7 +230,7 @@ fn test_into_conversions_with_int_id() {
     };
 
     let expected_id = test.bar.to_string();
-    let result: JsonApiData<<Foo as ToJson>::Attrs> = test.into_json(&Default::default());
+    let result: JsonApiData<Foo> = test.into_json(&Default::default());
     assert_eq!(expected_id, result.id.expect("unexpected None on id!"));
     assert_eq!(2, result.attributes.foo.expect("unexpected None on foo!"));
     assert_eq!("abc".to_string(),
@@ -246,7 +245,7 @@ fn test_into_conversions_with_string_id() {
     };
 
     let expected_id = test.id.clone();
-    let result: JsonApiData<<Bar as ToJson>::Attrs> = test.into_json(&Default::default());
+    let result: JsonApiData<Bar> = test.into_json(&Default::default());
     assert_eq!(expected_id, result.id.expect("unexpected None on id!"));
     assert_eq!(1, result.attributes.bar.expect("unexpected None on bar!"));
 }

--- a/rustiful-test/tests/request_tests.rs
+++ b/rustiful-test/tests/request_tests.rs
@@ -75,7 +75,7 @@ impl JsonGet for Foo {
     fn find(id: Self::JsonApiIdType,
             params: &Self::Params,
             ctx: Self::Context)
-            -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error> {
+            -> Result<Option<JsonApiData<Self>>, Self::Error> {
 
         if id == "fail" {
             Err(TestError("fail in get".to_string()))
@@ -97,7 +97,7 @@ impl JsonIndex for Foo {
 
     fn find_all(params: &Self::Params,
                 ctx: Self::Context)
-                -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error> {
+                -> Result<Vec<JsonApiData<Self>>, Self::Error> {
         if let Some(_) = params.query_params.get("fail") {
             return Err(TestError("fail in index".to_string()));
         }
@@ -130,10 +130,10 @@ impl JsonPost for Foo {
     type Error = TestError;
     type Context = FooService;
 
-    fn create(json: JsonApiData<Self::Attrs>,
+    fn create(json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+              -> Result<JsonApiData<Self>, Self::Error> {
         if let Some(id) = json.id {
             if id == "fail" {
                 return Err(TestError("fail in post".to_string()));
@@ -155,10 +155,10 @@ impl JsonPatch for Foo {
     type Context = FooService;
 
     fn update(id: Self::JsonApiIdType,
-              json: JsonApiData<Self::Attrs>,
+              json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+              -> Result<JsonApiData<Self>, Self::Error> {
         if let Some(id) = json.id {
             if id == "fail" {
                 return Err(TestError("fail in patch".to_string()));
@@ -194,7 +194,7 @@ fn parse_json_api_index_get() {
         .get::<ContentType>()
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
-    let records: JsonApiArray<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
+    let records: JsonApiContainer<Vec<JsonApiData<Foo>>> = serde_json::from_str(&result).unwrap();
     let params = <Foo as JsonApiResource>::Params::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
@@ -203,8 +203,8 @@ fn parse_json_api_index_get() {
         title: "test".to_string(),
         published: true,
     };
-    let data: JsonApiData<<Foo as ToJson>::Attrs> = (test, &params).into();
-    let expected = JsonApiArray { data: vec![data] };
+    let data: JsonApiData<Foo> = (test, &params).into();
+    let expected = JsonApiContainer { data: vec![data] };
 
     assert_eq!(expected, records);
 }
@@ -221,11 +221,11 @@ fn parse_json_api_index_get_with_fieldset() {
         .get::<ContentType>()
         .expect("no content type found!");
     let result = response::extract_body_to_string(response);
-    let records: JsonApiArray<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
+    let records: JsonApiContainer<Vec<JsonApiData<Foo>>> = serde_json::from_str(&result).unwrap();
     let data = JsonApiData::new(Some("1"),
                                 "foos",
                                 <Foo as ToJson>::Attrs::new(Some("test".to_string()), None, None));
-    let expected = JsonApiArray { data: vec![data] };
+    let expected = JsonApiContainer { data: vec![data] };
 
     assert_eq!(expected, records);
 }
@@ -237,7 +237,7 @@ fn parse_json_api_single_get() {
                                 Headers::new(),
                                 &app_router());
     let result = response::extract_body_to_string(response.unwrap());
-    let record: JsonApiObject<<Foo as ToJson>::Attrs> = serde_json::from_str(&result).unwrap();
+    let record: JsonApiContainer<JsonApiData<Foo>> = serde_json::from_str(&result).unwrap();
     let params = <Foo as JsonApiResource>::Params::from_str("").expect("failed to unwrap params");
 
     let test = Foo {
@@ -246,8 +246,8 @@ fn parse_json_api_single_get() {
         title: "test".to_string(),
         published: true,
     };
-    let data: JsonApiData<<Foo as ToJson>::Attrs> = (test, &params).into();
-    let expected = JsonApiObject { data: data };
+    let data: JsonApiData<Foo> = (test, &params).into();
+    let expected = JsonApiContainer { data: data };
 
     assert_eq!(expected, record);
 }

--- a/rustiful-test/tests/service_tests.rs
+++ b/rustiful-test/tests/service_tests.rs
@@ -108,7 +108,7 @@ impl JsonGet for Test {
     fn find(id: Self::JsonApiIdType,
             params: &Self::Params,
             ctx: Self::Context)
-            -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error> {
+            -> Result<Option<JsonApiData<Self>>, Self::Error> {
         table
             .find(id)
             .first::<Test>(ctx.conn())
@@ -123,10 +123,10 @@ impl JsonPatch for Test {
     type Context = DB;
 
     fn update(id: Self::JsonApiIdType,
-              json: JsonApiData<Self::Attrs>,
+              json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+              -> Result<JsonApiData<Self>, Self::Error> {
         let record = table
             .find(&id)
             .first(ctx.conn())
@@ -146,10 +146,10 @@ impl JsonPost for Test {
     type Error = MyErr;
     type Context = DB;
 
-    fn create(json: JsonApiData<Self::Attrs>,
+    fn create(json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error> {
+              -> Result<JsonApiData<Self>, Self::Error> {
         let result: Test = json.try_into().map_err(|e| MyErr::UpdateError(e))?;
 
         diesel::insert(&result)
@@ -166,7 +166,7 @@ impl JsonIndex for Test {
 
     fn find_all(params: &Self::Params,
                 ctx: Self::Context)
-                -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error> {
+                -> Result<Vec<JsonApiData<Self>>, Self::Error> {
         let mut query = table.into_boxed();
 
         {

--- a/rustiful/src/array.rs
+++ b/rustiful/src/array.rs
@@ -1,6 +1,0 @@
-use data::JsonApiData;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct JsonApiArray<T> {
-    pub data: Vec<JsonApiData<T>>
-}

--- a/rustiful/src/container.rs
+++ b/rustiful/src/container.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Contains JSONAPI data.
+///
+/// `data` should be either `JsonApiData<T::Attrs>` or `Vec<JsonApiData<T:Attrs>>`, where `T` is an
+/// implementation of `ToJson`.
+pub struct JsonApiContainer<T> {
+    pub data: T
+}

--- a/rustiful/src/iron/handlers/patch.rs
+++ b/rustiful/src/iron/handlers/patch.rs
@@ -12,7 +12,6 @@ use errors::IdParseError;
 use errors::QueryStringParseError;
 use errors::RequestError;
 use iron::id;
-use object::JsonApiObject;
 use request::patch::patch;
 use serde::Deserialize;
 use service::JsonPatch;
@@ -23,10 +22,12 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 use try_from::TryInto;
+use container::JsonApiContainer;
+use data::JsonApiData;
 
 autoimpl! {
     pub trait PatchHandler<'a, T> where
-        T: JsonPatch + ToJson,
+        T: 'static + JsonPatch + ToJson,
         T::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
         T::Attrs: 'static + for<'b> Deserialize<'b>,
@@ -35,7 +36,7 @@ autoimpl! {
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let json = match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
+            let json = match req.get::<bodyparser::Struct<JsonApiContainer<JsonApiData<T>>>>() {
                 Ok(Some(patch)) => patch,
                 Ok(None) => {
                     let err:RequestError<T::Error, T::JsonApiIdType> = RequestError::NoBody;

--- a/rustiful/src/iron/handlers/post.rs
+++ b/rustiful/src/iron/handlers/post.rs
@@ -10,7 +10,6 @@ use FromRequest;
 use errors::FromRequestError;
 use errors::QueryStringParseError;
 use errors::RequestError;
-use object::JsonApiObject;
 use request::post::post;
 use serde::Deserialize;
 use service::JsonPost;
@@ -21,10 +20,12 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 use try_from::TryInto;
+use data::JsonApiData;
+use container::JsonApiContainer;
 
 autoimpl! {
     pub trait PostHandler<'a, T> where
-        T: JsonPost + ToJson,
+        T: 'static + JsonPost + ToJson,
         T::Error: 'static,
         <T::Context as FromRequest>::Error: 'static,
         Status: for<'b> From<&'b T::Error>,
@@ -34,7 +35,7 @@ autoimpl! {
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let json = match req.get::<bodyparser::Struct<JsonApiObject<T::Attrs>>>() {
+            let json = match req.get::<bodyparser::Struct<JsonApiContainer<JsonApiData<T>>>>() {
                 Ok(Some(patch)) => patch,
                 Ok(None) => {
                     let err:RequestError<T::Error, T::JsonApiIdType> = RequestError::NoBody;

--- a/rustiful/src/iron/mod.rs
+++ b/rustiful/src/iron/mod.rs
@@ -199,7 +199,7 @@ fn id<'a>(req: &'a Request) -> &'a str {
 /// #
 /// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
 /// #                 ctx: Self::Context)
-/// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+/// #            -> Result<Vec<rustiful::JsonApiData<Self>>, Self::Error> {
 /// #          Ok(vec![MyResource::default().into_json(params)])
 /// #      }
 /// }
@@ -285,7 +285,7 @@ fn id<'a>(req: &'a Request) -> &'a str {
 /// #
 /// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
 /// #                 ctx: Self::Context)
-/// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+/// #            -> Result<Vec<rustiful::JsonApiData<Self>>, Self::Error> {
 /// #          Ok(vec![MyResource::default().into_json(params)])
 /// #      }
 /// # }
@@ -465,7 +465,7 @@ impl JsonApiRouterBuilder {
     /// #
     /// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #                 ctx: Self::Context)
-    /// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #            -> Result<Vec<rustiful::JsonApiData<Self>>, Self::Error> {
     /// #          Ok(vec![MyResource::default().into_json(params)])
     /// #      }
     /// }
@@ -536,7 +536,7 @@ impl JsonApiRouterBuilder {
     /// #
     /// #     fn find_all(params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #                 ctx: Self::Context)
-    /// #            -> Result<Vec<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #            -> Result<Vec<rustiful::JsonApiData<Self>>, Self::Error> {
     /// #          Ok(vec![MyResource::default().into_json(params)])
     /// #      }
     /// # }
@@ -636,7 +636,7 @@ impl JsonApiRouterBuilder {
     /// #     fn find(id: Self::JsonApiIdType,
     /// #             params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #             ctx: Self::Context)
-    /// #            -> Result<Option<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #            -> Result<Option<rustiful::JsonApiData<Self>>, Self::Error> {
     /// #          Ok(Some(MyResource::default().into_json(params)))
     /// #      }
     /// }
@@ -708,7 +708,7 @@ impl JsonApiRouterBuilder {
     /// #     fn find(id: Self::JsonApiIdType,
     /// #             params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #             ctx: Self::Context)
-    /// #            -> Result<Option<rustiful::JsonApiData<Self::Attrs>>, Self::Error> {
+    /// #            -> Result<Option<rustiful::JsonApiData<Self>>, Self::Error> {
     /// #          Ok(Some(MyResource::default().into_json(params)))
     /// #      }
     /// # }
@@ -966,10 +966,10 @@ impl JsonApiRouterBuilder {
     /// #    type Context = MyCtx;
     /// #    type Error = MyError;
     /// #
-    /// #    fn create(json: rustiful::JsonApiData<Self::Attrs>,
+    /// #    fn create(json: rustiful::JsonApiData<Self>,
     /// #         params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #          ctx: Self::Context)
-    /// #          -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #          -> Result<rustiful::JsonApiData<Self>, Self::Error> {
     /// #         Ok(MyResource::default().into_json(params))
     /// #    }
     /// }
@@ -1037,10 +1037,10 @@ impl JsonApiRouterBuilder {
     /// #    type Context = MyCtx;
     /// #    type Error = MyError;
     /// #
-    /// #    fn create(json: rustiful::JsonApiData<Self::Attrs>,
+    /// #    fn create(json: rustiful::JsonApiData<Self>,
     /// #         params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #          ctx: Self::Context)
-    /// #          -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #          -> Result<rustiful::JsonApiData<Self>, Self::Error> {
     /// #         let resource = MyResource {
     /// #             id: "some_id".to_string(),
     /// #             foo: true,
@@ -1065,7 +1065,7 @@ impl JsonApiRouterBuilder {
     /// This resource will then have the route `POST /my-resources`.
     pub fn jsonapi_post<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonPost + for<'b> PostHandler<'b, T>,
+              T: 'static + JsonPost + for<'b> PostHandler<'b, T>,
               T::Error: 'static,
               T::Attrs: 'static + for<'b> Deserialize<'b>,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
@@ -1144,10 +1144,10 @@ impl JsonApiRouterBuilder {
     /// #    type Error = MyError;
     /// #
     /// #    fn update(id: Self::JsonApiIdType,
-    /// #              json: rustiful::JsonApiData<Self::Attrs>,
+    /// #              json: rustiful::JsonApiData<Self>,
     /// #              params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #              ctx: Self::Context)
-    /// #              -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #              -> Result<rustiful::JsonApiData<Self>, Self::Error> {
     /// #         let resource = MyResource {
     /// #             id: "some_id".to_string(),
     /// #             foo: true,
@@ -1222,10 +1222,10 @@ impl JsonApiRouterBuilder {
     /// #    type Error = MyError;
     /// #
     /// #    fn update(id: Self::JsonApiIdType,
-    /// #              json: rustiful::JsonApiData<Self::Attrs>,
+    /// #              json: rustiful::JsonApiData<Self>,
     /// #              params: &rustiful::JsonApiParams<Self::FilterField, Self::SortField>,
     /// #              ctx: Self::Context)
-    /// #              -> Result<rustiful::JsonApiData<Self::Attrs>, Self::Error> {
+    /// #              -> Result<rustiful::JsonApiData<Self>, Self::Error> {
     /// #         let resource = MyResource {
     /// #             id: "some_id".to_string(),
     /// #             foo: true,
@@ -1251,7 +1251,7 @@ impl JsonApiRouterBuilder {
     /// This resource will then have the route `PATCH /my-resources/{id}`.
     pub fn jsonapi_patch<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonPatch + for<'b> PatchHandler<'b, T>,
+              T: 'static + JsonPatch + for<'b> PatchHandler<'b, T>,
               T::Error: 'static,
               T::Attrs: 'static + for<'b> Deserialize<'b>,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -24,11 +24,8 @@ pub use params::*;
 mod errors;
 pub use errors::query_string_parse_error::QueryStringParseError;
 
-mod array;
-pub use array::*;
-
-mod object;
-pub use object::*;
+mod container;
+pub use container::*;
 
 mod error;
 pub use error::*;

--- a/rustiful/src/object.rs
+++ b/rustiful/src/object.rs
@@ -1,6 +1,0 @@
-use data::JsonApiData;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct JsonApiObject<T> {
-    pub data: JsonApiData<T>
-}

--- a/rustiful/src/request/get.rs
+++ b/rustiful/src/request/get.rs
@@ -2,13 +2,14 @@ use super::Status;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
-use object::JsonApiObject;
 use service::JsonGet;
 use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
+use data::JsonApiData;
+use container::JsonApiContainer;
 
 /// This is a utility function that calls `T::find()` and returns `JsonApiObject<T::Attrs>` if
 /// successful.
@@ -16,7 +17,7 @@ use try_from::TryFrom;
 pub fn get<'a, T>(id: T::JsonApiIdType,
                   query: &'a str,
                   ctx: T::Context)
-                  -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+                  -> Result<JsonApiContainer<JsonApiData<T>>, RequestError<T::Error, T::JsonApiIdType>>
     where T: ToJson + JsonGet,
           <T::JsonApiIdType as FromStr>::Err: Error,
           Status: for<'b> From<&'b T::Error>,
@@ -27,5 +28,5 @@ pub fn get<'a, T>(id: T::JsonApiIdType,
     let result = T::find(id, &params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
     let data = result.ok_or(RequestError::NotFound)?;
-    Ok(JsonApiObject::<_> { data: data })
+    Ok(JsonApiContainer { data: data })
 }

--- a/rustiful/src/request/index.rs
+++ b/rustiful/src/request/index.rs
@@ -1,5 +1,4 @@
 use super::Status;
-use array::JsonApiArray;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
@@ -9,13 +8,15 @@ use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
+use data::JsonApiData;
+use container::JsonApiContainer;
 
 /// This is a utility function that calls `T::find_all()` and returns `JsonApiObject<T::Attrs>` if
 /// successful.
 ///
 pub fn index<'a, T>(query: &'a str,
                     ctx: T::Context)
-                    -> Result<JsonApiArray<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+                    -> Result<JsonApiContainer<Vec<JsonApiData<T>>>, RequestError<T::Error, T::JsonApiIdType>>
     where T: ToJson + JsonIndex,
           <T::JsonApiIdType as FromStr>::Err: Error,
           Status: for<'b> From<&'b T::Error>,
@@ -26,5 +27,5 @@ pub fn index<'a, T>(query: &'a str,
         .map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::find_all(&params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
-    Ok(JsonApiArray::<_> { data: result })
+    Ok(JsonApiContainer { data: result })
 }

--- a/rustiful/src/request/patch.rs
+++ b/rustiful/src/request/patch.rs
@@ -3,21 +3,21 @@ use data::JsonApiData;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
-use object::JsonApiObject;
 use service::JsonPatch;
 use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use try_from::TryFrom;
+use container::JsonApiContainer;
 
 /// This is a utility function that calls `T::update()` and returns `JsonApiObject<T::Attrs>` if
 /// successful.
 ///
 pub fn patch<'a, T>(id: T::JsonApiIdType,
                     query: &'a str,
-                    json: JsonApiData<T::Attrs>,
+                    json: JsonApiData<T>,
                     ctx: T::Context)
-                    -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+                    -> Result<JsonApiContainer<JsonApiData<T>>, RequestError<T::Error, T::JsonApiIdType>>
     where T: JsonPatch,
           Status: for<'b> From<&'b T::Error>,
           T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
@@ -28,5 +28,5 @@ pub fn patch<'a, T>(id: T::JsonApiIdType,
         .map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::update(id, json, &params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
-    Ok(JsonApiObject::<_> { data: result })
+    Ok(JsonApiContainer { data: result })
 }

--- a/rustiful/src/request/post.rs
+++ b/rustiful/src/request/post.rs
@@ -3,20 +3,20 @@ use data::JsonApiData;
 use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
-use object::JsonApiObject;
 use service::JsonPost;
 use params::SortOrder;
 use std::error::Error;
 use std::str::FromStr;
 use try_from::TryFrom;
+use container::JsonApiContainer;
 
 /// This is a utility function that calls `T::create()` and returns `JsonApiObject<T::Attrs>` if
 /// successful.
 ///
 pub fn post<'a, T>(query: &'a str,
-                   json: JsonApiData<T::Attrs>,
+                   json: JsonApiData<T>,
                    ctx: T::Context)
-                   -> Result<JsonApiObject<T::Attrs>, RequestError<T::Error, T::JsonApiIdType>>
+                   -> Result<JsonApiContainer<JsonApiData<T>>, RequestError<T::Error, T::JsonApiIdType>>
     where T: JsonPost,
           Status: for<'b> From<&'b T::Error>,
           T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
@@ -27,5 +27,5 @@ pub fn post<'a, T>(query: &'a str,
         .map_err(|e| RequestError::QueryStringParseError(e))?;
     let result = T::create(json, &params, ctx)
         .map_err(|e| RequestError::RepositoryError(RepositoryError::new(e)))?;
-    Ok(JsonApiObject::<_> { data: result })
+    Ok(JsonApiContainer { data: result })
 }

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -15,7 +15,7 @@ pub trait JsonGet where Self: JsonApiResource + ToJson
     fn find(id: Self::JsonApiIdType,
             params: &Self::Params,
             ctx: Self::Context)
-            -> Result<Option<JsonApiData<Self::Attrs>>, Self::Error>
+            -> Result<Option<JsonApiData<Self>>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
@@ -24,10 +24,10 @@ pub trait JsonPost where Self: JsonApiResource + ToJson
     type Error: std::error::Error + Send;
     type Context: FromRequest;
 
-    fn create(json: JsonApiData<Self::Attrs>,
+    fn create(json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error>
+              -> Result<JsonApiData<Self>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
@@ -37,10 +37,10 @@ pub trait JsonPatch where Self: JsonApiResource + ToJson
     type Context: FromRequest;
 
     fn update(id: Self::JsonApiIdType,
-              json: JsonApiData<Self::Attrs>,
+              json: JsonApiData<Self>,
               params: &Self::Params,
               ctx: Self::Context)
-              -> Result<JsonApiData<Self::Attrs>, Self::Error>
+              -> Result<JsonApiData<Self>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 
@@ -51,7 +51,7 @@ pub trait JsonIndex where Self: JsonApiResource + ToJson
 
     fn find_all(params: &Self::Params,
                 ctx: Self::Context)
-                -> Result<Vec<JsonApiData<Self::Attrs>>, Self::Error>
+                -> Result<Vec<JsonApiData<Self>>, Self::Error>
         where Status: for<'b> From<&'b Self::Error>;
 }
 

--- a/rustiful/src/to_json.rs
+++ b/rustiful/src/to_json.rs
@@ -1,7 +1,8 @@
 use serde::ser::Serialize;
+use serde::de::DeserializeOwned;
 
 pub trait ToJson {
-    type Attrs: Clone + Serialize;
+    type Attrs: Clone + Serialize + DeserializeOwned;
 
     fn id(&self) -> String;
 


### PR DESCRIPTION
Previously there were two separate container types, one which contained
a list of `JsonApiData<T>` and one which contained just a single
`JsonApiData<T>`.

Now we have just a JsonApiContainer<T>, which can hold both types. To
make the type signature less odious, JsonApiData is now constrained to
hold only types that implement `ToJson`.