### PR TITLE
Handler lifetime and type parameter changes

### DIFF
--- a/rustiful/Cargo.toml
+++ b/rustiful/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = "1.0"
 hyper = "0.10"
 uuid = { version = "0.5", optional = true, features = ["serde"] }
 rustiful-derive = { version = "0.1", optional = true }
-autoimpl = "0.1"
 url = "1.4"
 
 router = { version = "0.5", optional = true }

--- a/rustiful/src/iron/handlers/delete.rs
+++ b/rustiful/src/iron/handlers/delete.rs
@@ -12,28 +12,30 @@ use service::JsonDelete;
 use std::error::Error;
 use std::str::FromStr;
 
-autoimpl! {
-    pub trait DeleteHandler<'a, T>
-        where T: JsonDelete,
-              T::Error: 'static,
-              Status: for<'b> From<&'b T::Error>,
-              <T::JsonApiIdType as FromStr>::Err: Error
+pub trait DeleteHandler
+    where Self: JsonDelete
+{
+    fn respond<'r>(req: &'r mut Request) -> IronResult<Response>
+        where Status: for<'b> From<&'b Self::Error>,
+              <Self::JsonApiIdType as FromStr>::Err: Error
     {
-        fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let ctx = match <T::Context as FromRequest>::from_request(req) {
-                Ok(result) => result,
-                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            };
-
-            let id = match <T::JsonApiIdType>::from_str(id(req)) {
-                Ok(result) => result,
-                Err(e) => return IdParseError(e).into()
-            };
-
-            match T::delete(id, ctx) {
-                Ok(_) => Ok(Response::with((json_api_type(), Status::NoContent))),
-                Err(e) => RepositoryError::new(e).into()
+        let ctx = match <Self::Context as FromRequest>::from_request(req) {
+            Ok(result) => result,
+            Err(e) => {
+                return FromRequestError::<<Self::Context as FromRequest>::Error>(e).into()
             }
+        };
+
+        let id = match <Self::JsonApiIdType>::from_str(id(req)) {
+            Ok(result) => result,
+            Err(e) => return IdParseError(e).into(),
+        };
+
+        match Self::delete(id, ctx) {
+            Ok(_) => Ok(Response::with((json_api_type(), Status::NoContent))),
+            Err(e) => RepositoryError::new(e).into(),
         }
     }
 }
+
+impl<T> DeleteHandler for T where T: JsonDelete {}

--- a/rustiful/src/iron/handlers/get.rs
+++ b/rustiful/src/iron/handlers/get.rs
@@ -20,36 +20,39 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 
-autoimpl! {
-    pub trait GetHandler<'a, T> where
-        T: JsonGet + ToJson,
-        T::Error: 'static,
-        Status: for<'b> From<&'b T::Error>,
-        T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-        T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        <T::JsonApiIdType as FromStr>::Err: Error
+pub trait GetHandler
+    where Self: JsonGet
+{
+    fn respond<'r>(req: &'r mut Request) -> IronResult<Response>
+        where Status: for<'b> From<&'b Self::Error>,
+              Self: ToJson,
+              Self::SortField: TryFrom<(&'r str, SortOrder), Error = QueryStringParseError>,
+              Self::FilterField: TryFrom<(&'r str, Vec<&'r str>), Error = QueryStringParseError>,
+              <Self::JsonApiIdType as FromStr>::Err: Error
     {
-        fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let ctx = match <T::Context as FromRequest>::from_request(req) {
-                Ok(result) => result,
-                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            };
-
-            let id = match <T::JsonApiIdType>::from_str(id(req)) {
-                Ok(result) => result,
-                Err(e) => return IdParseError(e).into()
-            };
-
-            let params = match T::Params::from_str(req.url.query().unwrap_or("")) {
-                Ok(result) => result,
-                Err(e) => return e.into()
-            };
-
-            match T::find(id, &params, ctx) {
-                Ok(Some(result)) => into_json_api_response(result, Status::Ok),
-                Ok(None) => RequestError::NotFound.into(),
-                Err(e) => RepositoryError::new(e).into()
+        let ctx = match <Self::Context as FromRequest>::from_request(req) {
+            Ok(result) => result,
+            Err(e) => {
+                return FromRequestError::<<Self::Context as FromRequest>::Error>(e).into()
             }
+        };
+
+        let id = match <Self::JsonApiIdType>::from_str(id(req)) {
+            Ok(result) => result,
+            Err(e) => return IdParseError(e).into(),
+        };
+
+        let params = match Self::Params::from_str(req.url.query().unwrap_or("")) {
+            Ok(result) => result,
+            Err(e) => return e.into(),
+        };
+
+        match Self::find(id, &params, ctx) {
+            Ok(Some(result)) => into_json_api_response(result, Status::Ok),
+            Ok(None) => RequestError::NotFound.into(),
+            Err(e) => RepositoryError::new(e).into(),
         }
     }
 }
+
+impl<T> GetHandler for T where T: JsonGet {}

--- a/rustiful/src/iron/handlers/index.rs
+++ b/rustiful/src/iron/handlers/index.rs
@@ -1,7 +1,4 @@
 extern crate iron;
-extern crate bodyparser;
-extern crate serde;
-extern crate serde_json;
 
 use self::iron::prelude::*;
 use super::super::into_json_api_response;
@@ -12,35 +9,36 @@ use errors::RepositoryError;
 use params::SortOrder;
 use service::JsonIndex;
 use status::Status;
-use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 
-autoimpl! {
-    pub trait IndexHandler<'a, T> where
-        T: JsonIndex + ToJson,
-        T::Error: 'static,
-        Status: for<'b> From<&'b T::Error>,
-        T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-        T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        <T::JsonApiIdType as FromStr>::Err: Error
+pub trait IndexHandler
+    where Self: JsonIndex
+{
+    fn respond<'r>(req: &'r mut Request) -> IronResult<Response>
+        where Status: for<'b> From<&'b Self::Error>,
+              Self: ToJson,
+              Self::SortField: TryFrom<(&'r str, SortOrder), Error = QueryStringParseError>,
+              Self::FilterField: TryFrom<(&'r str, Vec<&'r str>), Error = QueryStringParseError>
     {
-        fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let ctx = match <T::Context as FromRequest>::from_request(req) {
-                Ok(result) => result,
-                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            };
-
-            let params = match T::Params::from_str(req.url.query().unwrap_or("")) {
-                Ok(result) => result,
-                Err(e) => return e.into()
-            };
-
-            match T::find_all(&params, ctx) {
-                Ok(result) => into_json_api_response(result, Status::Ok),
-                Err(e) => RepositoryError::new(e).into()
+        let ctx = match <Self::Context as FromRequest>::from_request(req) {
+            Ok(result) => result,
+            Err(e) => {
+                return FromRequestError::<<Self::Context as FromRequest>::Error>(e).into()
             }
+        };
+
+        let params = match Self::Params::from_str(req.url.query().unwrap_or("")) {
+            Ok(result) => result,
+            Err(e) => return e.into(),
+        };
+
+        match Self::find_all(&params, ctx) {
+            Ok(result) => into_json_api_response(result, Status::Ok),
+            Err(e) => RepositoryError::new(e).into(),
         }
     }
 }
+
+impl<T> IndexHandler for T where T: JsonIndex {}

--- a/rustiful/src/iron/handlers/patch.rs
+++ b/rustiful/src/iron/handlers/patch.rs
@@ -1,7 +1,5 @@
 extern crate iron;
 extern crate bodyparser;
-extern crate serde;
-extern crate serde_json;
 
 use self::iron::prelude::*;
 use super::errors::BodyParserError;
@@ -16,7 +14,6 @@ use errors::RepositoryError;
 use errors::RequestError;
 use iron::id;
 use params::SortOrder;
-use serde::Deserialize;
 use service::JsonPatch;
 use status::Status;
 use std::error::Error;
@@ -24,42 +21,45 @@ use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 
-autoimpl! {
-    pub trait PatchHandler<'a, T> where
-        T: 'static + JsonPatch + ToJson,
-        T::Error: 'static,
-        Status: for<'b> From<&'b T::Error>,
-        T::Attrs: 'static + for<'b> Deserialize<'b>,
-        T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-        T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        <T::JsonApiIdType as FromStr>::Err: Error
+pub trait PatchHandler
+    where Self: JsonPatch
+{
+    fn respond<'r>(req: &'r mut Request) -> IronResult<Response>
+        where Status: for<'b> From<&'b Self::Error>,
+              Self: 'static,
+              Self: ToJson,
+              Self::SortField: TryFrom<(&'r str, SortOrder), Error = QueryStringParseError>,
+              Self::FilterField: TryFrom<(&'r str, Vec<&'r str>), Error = QueryStringParseError>,
+              <Self::JsonApiIdType as FromStr>::Err: Error
     {
-        fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let json = match req.get::<bodyparser::Struct<JsonApiContainer<JsonApiData<T>>>>() {
-                Ok(Some(patch)) => patch,
-                Ok(None) => return RequestError::NoBody.into(),
-                Err(e) => return BodyParserError(e).into()
-            };
+        let json = match req.get::<bodyparser::Struct<JsonApiContainer<JsonApiData<Self>>>>() {
+            Ok(Some(patch)) => patch,
+            Ok(None) => return RequestError::NoBody.into(),
+            Err(e) => return BodyParserError(e).into(),
+        };
 
-            let ctx = match <T::Context as FromRequest>::from_request(req) {
-                Ok(result) => result,
-                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            };
-
-            let id = match <T::JsonApiIdType>::from_str(id(req)) {
-                Ok(result) => result,
-                Err(e) => return IdParseError(e).into()
-            };
-
-            let params = match T::Params::from_str(req.url.query().unwrap_or("")) {
-                Ok(result) => result,
-                Err(e) => return e.into()
-            };
-
-            match T::update(id, json.data, &params, ctx) {
-                Ok(result) => into_json_api_response(result, Status::Ok),
-                Err(e) => RepositoryError::new(e).into()
+        let ctx = match <Self::Context as FromRequest>::from_request(req) {
+            Ok(result) => result,
+            Err(e) => {
+                return FromRequestError::<<Self::Context as FromRequest>::Error>(e).into()
             }
+        };
+
+        let id = match <Self::JsonApiIdType>::from_str(id(req)) {
+            Ok(result) => result,
+            Err(e) => return IdParseError(e).into(),
+        };
+
+        let params = match Self::Params::from_str(req.url.query().unwrap_or("")) {
+            Ok(result) => result,
+            Err(e) => return e.into(),
+        };
+
+        match Self::update(id, json.data, &params, ctx) {
+            Ok(result) => into_json_api_response(result, Status::Ok),
+            Err(e) => RepositoryError::new(e).into(),
         }
     }
 }
+
+impl<T> PatchHandler for T where T: JsonPatch {}

--- a/rustiful/src/iron/handlers/post.rs
+++ b/rustiful/src/iron/handlers/post.rs
@@ -1,7 +1,5 @@
 extern crate iron;
 extern crate bodyparser;
-extern crate serde;
-extern crate serde_json;
 
 use self::iron::prelude::*;
 use super::errors::BodyParserError;
@@ -14,46 +12,45 @@ use errors::QueryStringParseError;
 use errors::RepositoryError;
 use errors::RequestError;
 use params::SortOrder;
-use serde::Deserialize;
 use service::JsonPost;
 use status::Status;
-use std::error::Error;
 use std::str::FromStr;
 use to_json::ToJson;
 use try_from::TryFrom;
 
-autoimpl! {
-    pub trait PostHandler<'a, T> where
-        T: 'static + JsonPost + ToJson,
-        T::Error: 'static,
-        <T::Context as FromRequest>::Error: 'static,
-        Status: for<'b> From<&'b T::Error>,
-        T::Attrs: 'static + for<'b> Deserialize<'b>,
-        T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
-        T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>,
-        <T::JsonApiIdType as FromStr>::Err: Error
+pub trait PostHandler
+    where Self: JsonPost
+{
+    fn respond<'r>(req: &'r mut Request) -> IronResult<Response>
+        where Status: for<'b> From<&'b Self::Error>,
+              Self: 'static,
+              Self: ToJson,
+              Self::SortField: TryFrom<(&'r str, SortOrder), Error = QueryStringParseError>,
+              Self::FilterField: TryFrom<(&'r str, Vec<&'r str>), Error = QueryStringParseError>
     {
-        fn respond(req: &'a mut Request) -> IronResult<Response> {
-            let json = match req.get::<bodyparser::Struct<JsonApiContainer<JsonApiData<T>>>>() {
-                Ok(Some(patch)) => patch,
-                Ok(None) => return RequestError::NoBody.into(),
-                Err(e) => return BodyParserError(e).into()
-            };
+        let json = match req.get::<bodyparser::Struct<JsonApiContainer<JsonApiData<Self>>>>() {
+            Ok(Some(patch)) => patch,
+            Ok(None) => return RequestError::NoBody.into(),
+            Err(e) => return BodyParserError(e).into(),
+        };
 
-            let ctx = match <T::Context as FromRequest>::from_request(req) {
-                Ok(result) => result,
-                Err(e) => return FromRequestError::<<T::Context as FromRequest>::Error>(e).into()
-            };
-
-            let params = match T::Params::from_str(req.url.query().unwrap_or("")) {
-                Ok(result) => result,
-                Err(e) => return e.into()
-            };
-
-            match T::create(json.data, &params, ctx) {
-                Ok(result) => into_json_api_response(result, Status::Ok),
-                Err(e) => RepositoryError::new(e).into()
+        let ctx = match <Self::Context as FromRequest>::from_request(req) {
+            Ok(result) => result,
+            Err(e) => {
+                return FromRequestError::<<Self::Context as FromRequest>::Error>(e).into()
             }
+        };
+
+        let params = match Self::Params::from_str(req.url.query().unwrap_or("")) {
+            Ok(result) => result,
+            Err(e) => return e.into(),
+        };
+
+        match Self::create(json.data, &params, ctx) {
+            Ok(result) => into_json_api_response(result, Status::Ok),
+            Err(e) => RepositoryError::new(e).into(),
         }
     }
 }
+
+impl<T> PostHandler for T where T: JsonPost {}

--- a/rustiful/src/iron/router_builder.rs
+++ b/rustiful/src/iron/router_builder.rs
@@ -9,11 +9,8 @@ use self::router::Router;
 
 use super::handlers::*;
 use super::status::*;
-use FromRequest;
 use errors::QueryStringParseError;
 use params::SortOrder;
-use serde::de::Deserialize;
-use service::*;
 use std::error::Error;
 use std::str::FromStr;
 use try_from::TryFrom;
@@ -451,14 +448,11 @@ impl JsonApiRouterBuilder {
     /// This resource will then have the route `GET /my-resources`.
     pub fn jsonapi_index<'a, T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonIndex + for<'b> IndexHandler<'b, T>,
-              T::Error: 'static,
+              T: IndexHandler,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
-                                              Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Error + 'static
+                                              Error = QueryStringParseError>
     {
-
         self.router
             .get(format!("/{}", T::resource_name()),
                  move |r: &mut Request| T::respond(r),
@@ -621,16 +615,14 @@ impl JsonApiRouterBuilder {
     /// ```
     ///
     /// This resource will then have the route `GET /my-resources/{id}`.
-    pub fn jsonapi_get<'a, T>(&mut self)
+    pub fn jsonapi_get<T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonGet + for<'b> GetHandler<'b, T>,
-              T::Error: 'static,
+              T: GetHandler,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
                                               Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Error + 'static
+              <T::JsonApiIdType as FromStr>::Err: Error
     {
-
         self.router
             .get(format!("/{}/:id", T::resource_name()),
                  move |r: &mut Request| T::respond(r),
@@ -785,13 +777,11 @@ impl JsonApiRouterBuilder {
     /// ```
     ///
     /// This resource will then have the route `DELETE /my-resources/{id}`.
-    pub fn jsonapi_delete<'a, T>(&mut self)
+    pub fn jsonapi_delete<T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: JsonDelete + for<'b> DeleteHandler<'b, T>,
-              T::Error: 'static,
-              <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
+              T: DeleteHandler,
+              <T::JsonApiIdType as FromStr>::Err: Error
     {
-
         self.router
             .delete(format!("/{}/:id", T::resource_name()),
                     move |r: &mut Request| T::respond(r),
@@ -958,18 +948,14 @@ impl JsonApiRouterBuilder {
     /// # }
     /// ```
     /// This resource will then have the route `POST /my-resources`.
-    pub fn jsonapi_post<'a, T>(&mut self)
+    pub fn jsonapi_post<T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: 'static + JsonPost + for<'b> PostHandler<'b, T>,
-              T::Error: 'static,
-              T::Attrs: 'static + for<'b> Deserialize<'b>,
+              T: 'static,
+              T: PostHandler,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
-                                              Error = QueryStringParseError>,
-              <T::Context as FromRequest>::Error: 'static,
-              <T::JsonApiIdType as FromStr>::Err: Send + Error + 'static
+                                              Error = QueryStringParseError>
     {
-
         self.router
             .post(format!("/{}", T::resource_name()),
                   move |r: &mut Request| T::respond(r),
@@ -1144,17 +1130,15 @@ impl JsonApiRouterBuilder {
     /// ```
     ///
     /// This resource will then have the route `PATCH /my-resources/{id}`.
-    pub fn jsonapi_patch<'a, T>(&mut self)
+    pub fn jsonapi_patch<T>(&mut self)
         where Status: for<'b> From<&'b T::Error>,
-              T: 'static + JsonPatch + for<'b> PatchHandler<'b, T>,
-              T::Error: 'static,
-              T::Attrs: 'static + for<'b> Deserialize<'b>,
+              T: 'static,
+              T: PatchHandler,
               T::SortField: for<'b> TryFrom<(&'b str, SortOrder), Error = QueryStringParseError>,
               T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>),
                                               Error = QueryStringParseError>,
-              <T::JsonApiIdType as FromStr>::Err: Error + 'static
+              <T::JsonApiIdType as FromStr>::Err: Error
     {
-
         self.router
             .patch(format!("/{}/:id", T::resource_name()),
                    move |r: &mut Request| T::respond(r),

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -45,9 +45,6 @@ pub use iron::from_request::*;
 #[macro_use]
 extern crate serde_derive;
 
-#[macro_use]
-extern crate autoimpl;
-
 extern crate hyper;
 
 /// Status Codes


### PR DESCRIPTION
There's no need for a lifetime on the trait itself; rather we should
have the lifetimes on the `respond` functions. This makes it easier to
do blanket impls on the handlers, since there is no need for the
handlers to have any type parameters.

This also means we can remove the `autoimpl` dependency, since it only
works for traits with type parameters anyway.

This commit also removes any `where` clauses from the handlers which are
not needed, notably `Deserialize` and (some) of the `'static` bounds.