### PR TITLE
Run tests sequentially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,11 @@ before_install:
 before_script:
     - cargo install diesel_cli || true
     - psql -c 'create database rustiful_examples;' -U postgres
-    #- psql -U postgres travis -c 'create extension "uuid-ossp";'
 script:
     - diesel migration run --migration-dir rustiful-test/migrations
     - DATABASE_URL=$POSTGRES_URL diesel migration run --migration-dir examples/migrations
     - cargo build --all --verbose
-    # Let the SQLite tests run sequentially
-    - cargo test --all --verbose && RUST_TEST_THREADS=1 cargo test --all --verbose -- --ignored
+    - cargo test --all --verbose
 
 matrix:
   allow_failures:


### PR DESCRIPTION
We need to run the tests that use SQLite sequentially, since otherwise
the tests will error. The tests that depended on executing sequentially
were previously run as an ignored category, which meant we needed to
run the tests twice; first without the ignored tests and then another
test run with the ignored tests.

We can simply just use a mutex for the tests that need to be run
sequentially, which means that there's no risk of not running these
tests for whatever reason.