### PR TITLE
Refactor JsonApiData type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Create [JSONAPI](http://jsonapi.org), um, APIs in Rust.
 
-Rustiful is based on [Iron](http://ironframework.io) and works with stable Rust (>=1.15).    
+Rustiful is based on [Iron](http://ironframework.io) and works with stable Rust (>=1.20).    
 
 ## TODO
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 format_strings = false
 reorder_imports = true
 trailing_comma = "Never"
+error_on_line_overflow_comments = false

--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -1,5 +1,5 @@
-extern crate syn;
 extern crate inflector;
+extern crate syn;
 
 use self::inflector::Inflector;
 use quote::Ident;

--- a/rustiful-derive/src/json.rs
+++ b/rustiful-derive/src/json.rs
@@ -123,9 +123,7 @@ pub fn expand_json_api_models(
                     self.#json_api_id_ident.to_string()
                 }
 
-                fn type_name(&self) -> String {
-                    <#name as JsonApiResource>::resource_name().to_string()
-                }
+                const TYPE_NAME: &'static str = <#name as JsonApiResource>::RESOURCE_NAME;
             }
 
             /// Converts a `(T, T::Params)` to a `JsonApiAttributes`.

--- a/rustiful-derive/src/params.rs
+++ b/rustiful-derive/src/params.rs
@@ -119,10 +119,7 @@ pub fn expand_json_api_fields(
                 type Params = JsonApiParams<field, sort>;
                 type SortField = sort;
                 type FilterField = field;
-
-                fn resource_name() -> &'static str {
-                    #pluralized_name.as_ref()
-                }
+                const RESOURCE_NAME: &'static str = #pluralized_name;
             }
         }
     }

--- a/rustiful-derive/src/params.rs
+++ b/rustiful-derive/src/params.rs
@@ -1,5 +1,5 @@
-extern crate syn;
 extern crate inflector;
+extern crate syn;
 
 use self::inflector::Inflector;
 use super::quote::*;
@@ -100,7 +100,8 @@ pub fn expand_json_api_fields(
                                     #(#filter_cases),*
                                     _ => {
                                         let field_val = field.to_string();
-                                        return Err(QueryStringParseError::InvalidFieldValue(field_val))
+                                        let e = QueryStringParseError::InvalidFieldValue(field_val);
+                                        return Err(e)
                                     }
                                 }
                             }
@@ -134,14 +135,12 @@ fn get_json_name(name: &str, attrs: &[Attribute]) -> String {
     let serde_struct_rename_attr: Vec<_> = attrs
         .into_iter()
         .filter_map(|a| match a.value {
-            List(ref ident, ref values) if ident == "serde" => {
-                match values.first() {
-                    Some(&MetaItem(NameValue(ref i, Str(ref value, _)))) if i == "rename" => {
-                        Some(value.to_string())
-                    }
-                    _ => None
+            List(ref ident, ref values) if ident == "serde" => match values.first() {
+                Some(&MetaItem(NameValue(ref i, Str(ref value, _)))) if i == "rename" => {
+                    Some(value.to_string())
                 }
-            }
+                _ => None
+            },
             _ => None
         })
         .collect();

--- a/rustiful-test/tests/conversion_tests.rs
+++ b/rustiful-test/tests/conversion_tests.rs
@@ -36,7 +36,7 @@ fn test_into_conversions_with_string_id() {
 #[test]
 fn test_setting_of_id_in_try_from() {
     let json_attrs = <Test as ToJson>::Attrs::new(Some("3".to_string()), None, None);
-    let json = JsonApiData::new(Some("1".to_string()), "".to_string(), json_attrs);
+    let json = JsonApiData::new(Some("1".to_string()), json_attrs);
     let test = Test {
         id: "1".to_string(),
         title: "foo".to_string(),

--- a/rustiful-test/tests/iron/post_and_patch_tests.rs
+++ b/rustiful-test/tests/iron/post_and_patch_tests.rs
@@ -126,7 +126,6 @@ mutex_test! {
         let created = do_post_with_url(&data, "http://localhost:3000/tests?fields[tests]=title");
         let expected = JsonApiData::new(
             Some(id),
-            "tests",
             <Test as ToJson>::Attrs::new(Some("test".to_string()), Some(None), None),
         );
 
@@ -267,7 +266,6 @@ mutex_test! {
             let updated = do_patch_with_url(&id, &patch, "fields[tests]=title");
             let expected = JsonApiData::new(
                 Some(id),
-                "tests",
                 <Test as ToJson>::Attrs::new(Some("funky".to_string()), Some(None), None),
             );
 

--- a/rustiful-test/tests/iron/request_tests.rs
+++ b/rustiful-test/tests/iron/request_tests.rs
@@ -82,7 +82,6 @@ fn parse_json_api_index_get_with_fieldset() {
     let records: JsonApiContainer<Vec<JsonApiData<Foo>>> = serde_json::from_str(&result).unwrap();
     let data = JsonApiData::new(
         Some("1"),
-        "foos",
         <Foo as ToJson>::Attrs::new(Some("test".to_string()), None, None)
     );
     let expected = JsonApiContainer { data: vec![data] };

--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -1,7 +1,7 @@
 use params::JsonApiParams;
 use resource::JsonApiResource;
-use to_json::ToJson;
 use std::marker::PhantomData;
+use to_json::ToJson;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// The JSONAPI representation of a resource.
@@ -124,10 +124,7 @@ where
     T::Attrs: From<(T, &'a JsonApiParams<T::FilterField, T::SortField>)>
 {
     fn from((model, params): (T, &'a JsonApiParams<T::FilterField, T::SortField>)) -> Self {
-        JsonApiData::new(
-            Some(model.id()),
-            T::Attrs::from((model, params))
-        )
+        JsonApiData::new(Some(model.id()), T::Attrs::from((model, params)))
     }
 }
 

--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -1,6 +1,7 @@
 use params::JsonApiParams;
 use resource::JsonApiResource;
 use to_json::ToJson;
+use std::marker::PhantomData;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// The JSONAPI representation of a resource.
@@ -9,12 +10,14 @@ where
     T: ToJson,
     T::Attrs: Clone
 {
-    // The id of the JSONAPI resource.
+    /// The id of the JSONAPI resource.
     pub id: Option<String>,
     #[serde(rename = "type")]
-    // The type name of the JSONAPI resource, equivalent to the resource name.
-    pub lower_case_type: String,
-    // The attribute type of the JSONAPI resource.
+    #[serde(serialize_with = "::json::phantomdata::serialize")]
+    #[serde(deserialize_with = "::json::phantomdata::deserialize")]
+    /// The type name of the JSONAPI resource, equivalent to the resource name.
+    pub _type: PhantomData<T>,
+    /// The attribute type of the JSONAPI resource.
     pub attributes: T::Attrs
 }
 
@@ -23,14 +26,10 @@ where
     T: ToJson,
     T::Attrs: Clone
 {
-    pub fn new<Id: Into<String>, Type: Into<String>>(
-        id: Option<Id>,
-        lower_case_type: Type,
-        attrs: T::Attrs
-    ) -> JsonApiData<T> {
+    pub fn new<Id: Into<String>>(id: Option<Id>, attrs: T::Attrs) -> JsonApiData<T> {
         JsonApiData {
             id: id.map(|i| i.into()),
-            lower_case_type: lower_case_type.into(),
+            _type: PhantomData,
             attributes: attrs
         }
     }
@@ -49,7 +48,7 @@ where
     fn clone(&self) -> Self {
         JsonApiData {
             id: self.id.clone(),
-            lower_case_type: self.lower_case_type.clone(),
+            _type: self._type.clone(),
             attributes: self.attributes.clone()
         }
     }
@@ -127,7 +126,6 @@ where
     fn from((model, params): (T, &'a JsonApiParams<T::FilterField, T::SortField>)) -> Self {
         JsonApiData::new(
             Some(model.id()),
-            model.type_name(),
             T::Attrs::from((model, params))
         )
     }

--- a/rustiful/src/iron/router_builder.rs
+++ b/rustiful/src/iron/router_builder.rs
@@ -434,9 +434,9 @@ impl JsonApiRouterBuilder {
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>
     {
         self.router.get(
-            format!("/{}", T::resource_name()),
+            format!("/{}", T::RESOURCE_NAME),
             move |r: &mut Request| T::respond(r),
-            format!("index_{}", T::resource_name())
+            format!("index_{}", T::RESOURCE_NAME)
         );
     }
 
@@ -602,9 +602,9 @@ impl JsonApiRouterBuilder {
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         self.router.get(
-            format!("/{}/:id", T::resource_name()),
+            format!("/{}/:id", T::RESOURCE_NAME),
             move |r: &mut Request| T::respond(r),
-            format!("get_{}", T::resource_name())
+            format!("get_{}", T::RESOURCE_NAME)
         );
     }
 
@@ -760,9 +760,9 @@ impl JsonApiRouterBuilder {
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         self.router.delete(
-            format!("/{}/:id", T::resource_name()),
+            format!("/{}/:id", T::RESOURCE_NAME),
             move |r: &mut Request| T::respond(r),
-            format!("delete_{}", T::resource_name())
+            format!("delete_{}", T::RESOURCE_NAME)
         );
     }
 
@@ -933,9 +933,9 @@ impl JsonApiRouterBuilder {
         T::FilterField: for<'b> TryFrom<(&'b str, Vec<&'b str>), Error = QueryStringParseError>
     {
         self.router.post(
-            format!("/{}", T::resource_name()),
+            format!("/{}", T::RESOURCE_NAME),
             move |r: &mut Request| T::respond(r),
-            format!("create_{}", T::resource_name())
+            format!("create_{}", T::RESOURCE_NAME)
         );
     }
 
@@ -1114,9 +1114,9 @@ impl JsonApiRouterBuilder {
         <T::JsonApiIdType as FromStr>::Err: Error
     {
         self.router.patch(
-            format!("/{}/:id", T::resource_name()),
+            format!("/{}/:id", T::RESOURCE_NAME),
             move |r: &mut Request| T::respond(r),
-            format!("update_{}", T::resource_name())
+            format!("update_{}", T::RESOURCE_NAME)
         );
     }
 

--- a/rustiful/src/iron/router_builder.rs
+++ b/rustiful/src/iron/router_builder.rs
@@ -1,13 +1,12 @@
-extern crate iron;
-extern crate router;
 extern crate bodyparser;
+extern crate iron;
 extern crate persistent;
+extern crate router;
 
 use self::iron::prelude::*;
 use self::persistent::Read;
 use self::router::Router;
 use super::from_request::FromRequest;
-
 use super::handlers::*;
 use super::status::*;
 use errors::QueryStringParseError;

--- a/rustiful/src/json/mod.rs
+++ b/rustiful/src/json/mod.rs
@@ -1,2 +1,1 @@
 pub mod phantomdata;
-

--- a/rustiful/src/json/mod.rs
+++ b/rustiful/src/json/mod.rs
@@ -1,0 +1,2 @@
+pub mod phantomdata;
+

--- a/rustiful/src/json/phantomdata.rs
+++ b/rustiful/src/json/phantomdata.rs
@@ -1,13 +1,12 @@
-use to_json::ToJson;
-
-use std::marker::PhantomData;
-use serde::de::Error;
-use serde::de::Visitor;
-use serde::de::Unexpected;
 use serde::de::Deserializer;
+use serde::de::Error;
+use serde::de::Unexpected;
+use serde::de::Visitor;
 use serde::ser::Serializer;
 use std::fmt;
+use std::marker::PhantomData;
 use std::str;
+use to_json::ToJson;
 
 /// Serialises a `ToJson::TYPE_NAME` as a type property
 ///
@@ -72,7 +71,11 @@ use std::str;
 /// # }
 ///
 /// ```
-pub fn serialize<S, T>(_: &PhantomData<T>, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer, T: ToJson {
+pub fn serialize<S, T>(_: &PhantomData<T>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: ToJson
+{
     serializer.serialize_str(T::TYPE_NAME)
 }
 
@@ -158,7 +161,8 @@ pub fn serialize<S, T>(_: &PhantomData<T>, serializer: S) -> Result<S::Ok, S::Er
 /// # }
 ///
 /// ```
-pub fn deserialize<'de, D, T>(deserializer: D) -> Result<PhantomData<T>, D::Error> where
+pub fn deserialize<'de, D, T>(deserializer: D) -> Result<PhantomData<T>, D::Error>
+where
     T: ToJson,
     D: Deserializer<'de>
 {
@@ -180,36 +184,39 @@ impl<'de> Visitor<'de> for StringVisitor {
     }
 
     fn visit_str<E>(self, v: &str) -> Result<String, E>
-        where
-            E: Error,
+    where
+        E: Error
     {
         Ok(v.to_owned())
     }
 
     fn visit_string<E>(self, v: String) -> Result<String, E>
-        where
-            E: Error,
+    where
+        E: Error
     {
         Ok(v)
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<String, E>
-        where
-            E: Error,
+    where
+        E: Error
     {
         match str::from_utf8(v) {
             Ok(s) => Ok(s.to_owned()),
-            Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
+            Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self))
         }
     }
 
     fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<String, E>
-        where
-            E: Error,
+    where
+        E: Error
     {
         match String::from_utf8(v) {
             Ok(s) => Ok(s),
-            Err(e) => Err(Error::invalid_value(Unexpected::Bytes(&e.into_bytes()), &self),),
+            Err(e) => Err(Error::invalid_value(
+                Unexpected::Bytes(&e.into_bytes()),
+                &self
+            ))
         }
     }
 }

--- a/rustiful/src/json/phantomdata.rs
+++ b/rustiful/src/json/phantomdata.rs
@@ -1,0 +1,215 @@
+use to_json::ToJson;
+
+use std::marker::PhantomData;
+use serde::de::Error;
+use serde::de::Visitor;
+use serde::de::Unexpected;
+use serde::de::Deserializer;
+use serde::ser::Serializer;
+use std::fmt;
+use std::str;
+
+/// Serialises a `ToJson::TYPE_NAME` as a type property
+///
+/// # Example
+///
+/// Given a resource that implements `ToJson` (this is automatically implemented when
+/// deriving `JsonApi`), such as the one below:
+///
+/// ```
+/// # extern crate rustiful;
+/// #
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// #[derive(Debug, PartialEq, Eq, Clone, JsonApi, Default)]
+/// struct MyResource {
+///     id: String,
+///     foo: bool,
+///     bar: String
+/// }
+/// #
+/// # fn main() {
+/// # }
+/// ```
+///
+/// The `_type` field will be converted into a string value when serialising to JSON.
+///
+/// ```
+/// # extern crate rustiful;
+/// #
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// # extern crate serde_json;
+/// #
+/// # use rustiful::ToJson;
+/// # use rustiful::IntoJson;
+/// # use serde_json::Value;
+/// #
+/// #[derive(Debug, PartialEq, Eq, Clone, JsonApi, Default)]
+/// # struct MyResource {
+/// #     id: String,
+/// #     foo: bool,
+/// #     bar: String
+/// # }
+/// #
+/// # fn main() {
+/// let resource = MyResource {
+///     id: "foo".to_string(),
+///     foo: true,
+///     bar: "abc".to_string()
+/// };
+/// let json = serde_json::to_string(&resource.into_json(&Default::default())).unwrap();
+/// let v: Value = serde_json::from_str(&json).unwrap();
+/// assert_eq!(v["type"], MyResource::TYPE_NAME)
+/// # }
+///
+/// ```
+pub fn serialize<S, T>(_: &PhantomData<T>, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer, T: ToJson {
+    serializer.serialize_str(T::TYPE_NAME)
+}
+
+/// Deserialises a type property as a `PhantomData`. If there is a mismatch between a type name
+/// and `T:TYPE_NAME` an error will be returned.
+///
+/// # Example
+///
+/// Given a resource that implements `ToJson` (this is automatically implemented when
+/// deriving `JsonApi`), such as the one below:
+///
+/// ```
+/// # extern crate rustiful;
+/// #
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// #[derive(Debug, PartialEq, Eq, Clone, JsonApi, Default)]
+/// struct MyResource {
+///     id: String,
+///     foo: bool,
+///     bar: String
+/// }
+/// #
+/// # fn main() {
+/// # }
+/// ```
+///
+/// The `type` field will be converted into a `PhantomData` type on a successful deserialisation.
+///
+/// ```
+/// # extern crate rustiful;
+/// #
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # #[macro_use]
+/// # extern crate rustiful_derive;
+/// #
+/// # extern crate serde_json;
+/// #
+/// # use rustiful::ToJson;
+/// # use rustiful::JsonApiData;
+/// # use rustiful::JsonApiContainer;
+/// # use rustiful::IntoJson;
+/// # use serde_json::Value;
+/// # use std::error::Error;
+/// #
+/// #[derive(Debug, PartialEq, Eq, Clone, JsonApi, Default)]
+/// # struct MyResource {
+/// #     id: String,
+/// #     foo: bool,
+/// #     bar: String
+/// # }
+/// #
+/// # fn main() {
+/// let valid_data = r#"{
+///                    "id": "foo",
+///                    "type": "my-resources",
+///                    "attributes": {
+///                       "bar": "foo"
+///                    }
+///                }"#;
+/// // Should deserialise successfully
+/// let _: JsonApiData<MyResource> = serde_json::from_str(&valid_data).unwrap();
+///
+/// let invalid_type_name = r#"{
+///                                 "id": "foo",
+///                                 "type": "something-invalid",
+///                                 "attributes": {
+///                                     "bar": "foo"
+///                                 }
+///                             }"#;
+/// // Should fail to deserialise
+/// let err: Result<JsonApiData<MyResource>, _> = serde_json::from_str(&invalid_type_name);
+/// match err {
+///     Ok(_) => { assert!(false, "Unexpected deserialisation success!") },
+///     Err(e) => assert!(format!("{}", e).contains("Invalid type name 'something-invalid'"))
+/// }
+/// # }
+///
+/// ```
+pub fn deserialize<'de, D, T>(deserializer: D) -> Result<PhantomData<T>, D::Error> where
+    T: ToJson,
+    D: Deserializer<'de>
+{
+    let value = deserializer.deserialize_string(StringVisitor)?;
+    if value == T::TYPE_NAME {
+        Ok(PhantomData)
+    } else {
+        Err(D::Error::custom(format!("Invalid type name '{}'", value)))
+    }
+}
+
+struct StringVisitor;
+
+impl<'de> Visitor<'de> for StringVisitor {
+    type Value = String;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<String, E>
+        where
+            E: Error,
+    {
+        Ok(v.to_owned())
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<String, E>
+        where
+            E: Error,
+    {
+        Ok(v)
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<String, E>
+        where
+            E: Error,
+    {
+        match str::from_utf8(v) {
+            Ok(s) => Ok(s.to_owned()),
+            Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
+        }
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<String, E>
+        where
+            E: Error,
+    {
+        match String::from_utf8(v) {
+            Ok(s) => Ok(s),
+            Err(e) => Err(Error::invalid_value(Unexpected::Bytes(&e.into_bytes()), &self),),
+        }
+    }
+}

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![warn(missing_debug_implementations, missing_copy_implementations, trivial_casts,
-trivial_numeric_casts, unused_import_braces, unused_qualifications)]
+        trivial_numeric_casts, unused_import_braces, unused_qualifications)]
 
 extern crate serde;
 

--- a/rustiful/src/lib.rs
+++ b/rustiful/src/lib.rs
@@ -6,6 +6,8 @@ trivial_numeric_casts, unused_import_braces, unused_qualifications)]
 
 extern crate serde;
 
+mod json;
+
 mod to_json;
 pub use to_json::*;
 

--- a/rustiful/src/resource.rs
+++ b/rustiful/src/resource.rs
@@ -18,5 +18,5 @@ pub trait JsonApiResource: Sized {
     type JsonApiIdType: FromStr + Debug;
     /// This is typically the pluralized, lower-cased and dasherized name of the type deriving
     /// `JsonApi`.
-    fn resource_name() -> &'static str;
+    const RESOURCE_NAME: &'static str;
 }

--- a/rustiful/src/resource.rs
+++ b/rustiful/src/resource.rs
@@ -1,4 +1,3 @@
-
 use errors::QueryStringParseError;
 use std::fmt::Debug;
 use std::str::FromStr;

--- a/rustiful/src/service.rs
+++ b/rustiful/src/service.rs
@@ -86,7 +86,7 @@ pub trait Handler {
 ///     let id = "magic_id".to_string();
 ///     let attrs = <<MyResource as ToJson>::Attrs>::new(Some(true), Some("hello".to_string()));
 ///     let resource = MyResource::find(id.clone(), &Default::default(), MyCtx {});
-///     let expected = JsonApiData::new(Some(id), "my-resources".to_string(), attrs);
+///     let expected = JsonApiData::new(Some(id), attrs);
 ///     assert_eq!(expected, resource.unwrap().unwrap());
 ///
 ///     assert_eq!(Ok(None), MyResource::find("foo".to_string(), &Default::default(), MyCtx {}));
@@ -189,7 +189,7 @@ where
 /// fn main() {
 ///     let id = "some_id".to_string();
 ///     let attrs = <<MyResource as ToJson>::Attrs>::new(Some(true), Some("hello".to_string()));
-///     let mut resource = JsonApiData::new(Some(id), "my-resources".to_string(), attrs);
+///     let mut resource = JsonApiData::new(Some(id), attrs);
 ///
 ///     let err = Err((MyError("invalid id!".to_string()), Status::BadRequest));
 ///     assert_eq!(err, MyResource::create(resource.clone(), &Default::default(), MyCtx {}));
@@ -311,7 +311,7 @@ where
 /// fn main() {
 ///     let id = "magic_id".to_string();
 ///     let attrs = <<MyResource as ToJson>::Attrs>::new(None, Some("updated".to_string()));
-///     let json = JsonApiData::new(Some(id.clone()), "my-resources".to_string(), attrs);
+///     let json = JsonApiData::new(Some(id.clone()), attrs);
 ///
 ///     let expected = MyResource {
 ///         id: "magic_id".to_string(),
@@ -408,7 +408,7 @@ where
     ///
     ///     let id = "magic_id".to_string();
     ///     let attrs = <MyResource as ToJson>::Attrs::new(None, None);
-    ///     let mut json = JsonApiData::new(Some(id.clone()), "my-resources".to_string(), attrs);
+    ///     let mut json = JsonApiData::new(Some(id.clone()), attrs);
     ///
     ///     // Nothing gets changed here
     ///     let update_with_nones = resource.clone().patch(json.clone());
@@ -525,7 +525,7 @@ where
 ///     let id = "magic_id".to_string();
 ///     let attrs = <<MyResource as ToJson>::Attrs>::new(Some(true), Some("hello".to_string()));
 ///     let resource = MyResource::find_all(&Default::default(), MyCtx {});
-///     let expected = JsonApiData::new(Some(id), "my-resources".to_string(), attrs);
+///     let expected = JsonApiData::new(Some(id), attrs);
 ///     assert_eq!(vec![expected], resource.unwrap());
 /// }
 /// ```

--- a/rustiful/src/to_json.rs
+++ b/rustiful/src/to_json.rs
@@ -1,4 +1,3 @@
-
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 

--- a/rustiful/src/to_json.rs
+++ b/rustiful/src/to_json.rs
@@ -7,5 +7,5 @@ pub trait ToJson {
 
     fn id(&self) -> String;
 
-    fn type_name(&self) -> String;
+    const TYPE_NAME: &'static str;
 }


### PR DESCRIPTION
There's not actually a need to store the `type` parameter as a string in
the JsonApiData model; all we need to know when deserialising is that
the `type` parameter value is valid. During serialisation we will always
serialise the `type` parameter as `<T as ToJson>::TYPE_NAME`. Since
we already have the type info, it's pointless to store the type as a
string.

Also, since there's now support for const parameters in traits, we store
the `TYPE_NAME` as a const instead of having a method for it.