### PR TITLE
Make JsonApiData<T> _type field private

### DIFF
--- a/rustiful/src/data.rs
+++ b/rustiful/src/data.rs
@@ -16,7 +16,7 @@ where
     #[serde(serialize_with = "::json::phantomdata::serialize")]
     #[serde(deserialize_with = "::json::phantomdata::deserialize")]
     /// The type name of the JSONAPI resource, equivalent to the resource name.
-    pub _type: PhantomData<T>,
+    _type: PhantomData<T>,
     /// The attribute type of the JSONAPI resource.
     pub attributes: T::Attrs
 }


### PR DESCRIPTION
There's no reason for the `_type` field to be public. Follow-up on #54.